### PR TITLE
FIX: Resync topic titles.

### DIFF
--- a/app/jobs/regular/process_alert.rb
+++ b/app/jobs/regular/process_alert.rb
@@ -121,6 +121,10 @@ module Jobs
         ] = topic_body
 
         t.custom_fields[
+          DiscoursePrometheusAlertReceiver::TOPIC_BASE_TITLE_CUSTOM_FIELD
+        ] = base_title
+
+        t.custom_fields[
           DiscoursePrometheusAlertReceiver::TOPIC_TITLE_CUSTOM_FIELD
         ] = topic_title
 

--- a/app/jobs/regular/process_grouped_alerts.rb
+++ b/app/jobs/regular/process_grouped_alerts.rb
@@ -68,14 +68,18 @@ module Jobs
             topic.save_custom_fields(true)
             klass = DiscoursePrometheusAlertReceiver
 
+            if base_title = topic.custom_fields[klass::TOPIC_BASE_TITLE_CUSTOM_FIELD]
+              title = generate_title(base_title, alerts)
+            else
+              title = topic.custom_fields[klass::TOPIC_TITLE_CUSTOM_FIELD] || ''
+            end
+
             raw = first_post_body(
               receiver: receiver,
               topic_body: topic.custom_fields[klass::TOPIC_BODY_CUSTOM_FIELD] || '',
               alert_history: alerts,
               prev_topic_id: topic.custom_fields[klass::PREVIOUS_TOPIC_CUSTOM_FIELD]
             )
-
-            title = topic.custom_fields[klass::TOPIC_TITLE_CUSTOM_FIELD] || ''
 
             revise_topic(
               topic: topic,

--- a/plugin.rb
+++ b/plugin.rb
@@ -24,6 +24,7 @@ after_initialize do
     ALERT_HISTORY_CUSTOM_FIELD  = 'prom_alert_history'.freeze
     PREVIOUS_TOPIC_CUSTOM_FIELD = 'prom_previous_topic'.freeze
     TOPIC_BODY_CUSTOM_FIELD = 'prom_alert_topic_body'.freeze
+    TOPIC_BASE_TITLE_CUSTOM_FIELD = 'prom_alert_topic_base_title'.freeze
     TOPIC_TITLE_CUSTOM_FIELD = 'prom_alert_topic_title'.freeze
 
     class Engine < ::Rails::Engine

--- a/spec/integration/discourse_prometheus_alert_receiver/receiver_controller_spec.rb
+++ b/spec/integration/discourse_prometheus_alert_receiver/receiver_controller_spec.rb
@@ -174,6 +174,10 @@ RSpec.describe DiscoursePrometheusAlertReceiver::ReceiverController do
             ]
           }
 
+          topic.custom_fields[
+            DiscoursePrometheusAlertReceiver::TOPIC_BASE_TITLE_CUSTOM_FIELD
+          ] = "some title"
+
           topic.save_custom_fields(true)
         end
 
@@ -313,6 +317,140 @@ RSpec.describe DiscoursePrometheusAlertReceiver::ReceiverController do
             expect(
               topic.custom_fields[custom_field_key]['alerts'].first['description']
             ).to eq('some description')
+          end
+
+          it 'should not update the topic if nothing has changed' do
+            post "/prometheus/receiver/grouped/alerts/#{token}", params: payload
+
+            messages = MessageBus.track_publish do
+              post "/prometheus/receiver/grouped/alerts/#{token}", params: payload
+            end
+
+            expect(messages).to eq([])
+          end
+        end
+
+        describe 'when payload is missing one alert' do
+          let(:payload) do
+            {
+              "status" => "success",
+              "externalURL" => "supposed.to.be.a.url",
+              "graphURL" => "to.be.a.url",
+              "data" => [
+                {
+                  "labels" => {
+                    "alertname" => alert_name,
+                    "datacenter" => datacenter
+                  },
+                  "groupKey" => group_key,
+                  "blocks" => [
+                    {
+                      "routeOpts" => {
+                        "receiver" => "somereceiver",
+                        "groupBy" => [
+                          "alertname",
+                          "datacenter"
+                        ],
+                        "groupWait" => 30000000000,
+                        "groupInterval" => 30000000000,
+                        "repeatInterval" => 3600000000000
+                      },
+                      "alerts" => [
+                        {
+                          "labels" => {
+                            "alertname" => alert_name,
+                            "datacenter" => "somedatacenter",
+                            'id' => 'somethingnotfunny',
+                            "instance" => "someinstance",
+                            "job" => "somejob",
+                            "notify" => "live"
+                          },
+                          "annotations" => {
+                            "description" => "some description",
+                            "topic_body" => "some body",
+                            "topic_title" => "some title"
+                          },
+                          "startsAt" => "2018-07-24T23:25:31.363742334Z",
+                          "endsAt" => "0001-01-01T00:00:00Z",
+                          "generatorURL" => "http://supposed.to.be.a.url/graph?g0.expr=lolrus",
+                          "status" => {
+                            "state" => "firing"
+                          },
+                          "receivers" => nil,
+                          "fingerprint" => "09aae3ea59ed5a65"
+                        },
+                        {
+                          "labels" => {
+                            "alertname" => alert_name,
+                            "datacenter" => "somedatacenter",
+                            'id' => 'somethingfunny',
+                            "instance" => "someinstance",
+                            "job" => "somejob",
+                            "notify" => "live"
+                          },
+                          "annotations" => {
+                            "description" => "some description",
+                            "topic_body" => "some body",
+                            "topic_title" => "some title"
+                          },
+                          "startsAt" => "2018-07-24T23:25:31.363742334Z",
+                          "endsAt" => "0001-01-01T00:00:00Z",
+                          "generatorURL" => "http://supposed.to.be.a.url/graph?g0.expr=lolrus",
+                          "status" => {
+                            "state" => "firing"
+                          },
+                          "receivers" => nil,
+                          "fingerprint" => "09aae3ea59ed5a65"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          end
+
+          it 'should update the alerts correctly' do
+            post "/prometheus/receiver/grouped/alerts/#{token}", params: payload
+
+            expect(response.status).to eq(200)
+
+            key = DiscoursePrometheusAlertReceiver::ALERT_HISTORY_CUSTOM_FIELD
+            alerts = topic.reload.custom_fields[key]["alerts"]
+
+            [
+              ['doesnotexists', 'stale'],
+              ['somethingfunny', 'firing'],
+              ['somethingnotfunny', 'firing']
+            ].each do |id, status|
+              expect(alerts.find { |alert| alert['id'] == id }["status"])
+                .to eq(status)
+            end
+
+            expect(topic.title).to eq("some title (2 firing)")
+
+            expect(topic.tags.pluck(:name)).to contain_exactly(
+              datacenter,
+              datacenter2,
+              "firing"
+            )
+
+            raw = first_post.reload.raw
+
+            expect(raw).to_not include("# :shushing_face: Silenced Alerts")
+            expect(raw).to include("## #{I18n.t('prom_alert_receiver.post.headers.stale')}")
+
+            expect(raw).to match(
+              /somethingfunny.*date=2018-07-24 time=23:25:31/
+            )
+
+            expect(raw).to match(
+              /somethingnotfunny.*date=2018-07-24 time=23:25:31/
+            )
+
+            expect(raw).to match(
+              /doesnotexists.*date=2018-07-24 time=23:25:31/
+            )
           end
 
           it 'should not update the topic if nothing has changed' do


### PR DESCRIPTION
`topic.custom_fields[klass::TOPIC_TITLE_CUSTOM_FIELD]` contains the generated title, including `(N firing)`. Instead of reusing that one, this PR uses `generate_title` to regenerate the title.