### PR TITLE
FIX: Use top-level namespace for base classes

### DIFF
--- a/app/jobs/regular/process_alert.rb
+++ b/app/jobs/regular/process_alert.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Jobs
-  class ProcessAlert < Jobs::Base
+  class ProcessAlert < ::Jobs::Base
     include AlertPostMixin
 
     def execute(args)

--- a/app/jobs/regular/process_grouped_alerts.rb
+++ b/app/jobs/regular/process_grouped_alerts.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Jobs
-  class ProcessGroupedAlerts < Jobs::Base
+  class ProcessGroupedAlerts < ::Jobs::Base
     sidekiq_options retry: false
 
     include AlertPostMixin


### PR DESCRIPTION
Zeitwerk is failing when we are searching for Jobs::Onceoff and Jobs::Base without going back to the top-level namespace (this is correlated to the fact that we got Onceoff base class and module with the same name). 

I noticed that in plugins we are using sometimes :: and sometimes not and that gives me comfort that this change will not break anything.

Travis error: https://travis-ci.org/discourse/discourse/jobs/585072364