### PR TITLE
REFACTOR: Move rendering to client-side

### DIFF
--- a/app/jobs/regular/process_alert.rb
+++ b/app/jobs/regular/process_alert.rb
@@ -84,6 +84,7 @@ module Jobs
       # explicitly declared as JSON fields, so we have to wrap our array in
       # a single-element hash.
       topic.custom_fields[::DiscoursePrometheusAlertReceiver::ALERT_HISTORY_CUSTOM_FIELD] = { 'alerts' => alert_history }
+      topic.custom_fields[::DiscoursePrometheusAlertReceiver::ALERT_HISTORY_VERSION_CUSTOM_FIELD] = 2
       topic.save_custom_fields
 
       MessageBus.publish("/alert-receiver",

--- a/app/jobs/regular/process_grouped_alerts.rb
+++ b/app/jobs/regular/process_grouped_alerts.rb
@@ -84,6 +84,7 @@ module Jobs
           end
 
           if updated
+            topic.custom_fields[::DiscoursePrometheusAlertReceiver::ALERT_HISTORY_VERSION_CUSTOM_FIELD] = 2
             topic.save_custom_fields(true)
             klass = DiscoursePrometheusAlertReceiver
 

--- a/assets/javascripts/discourse/widgets/alert-receiver.js.es6
+++ b/assets/javascripts/discourse/widgets/alert-receiver.js.es6
@@ -1,0 +1,278 @@
+import I18n from "I18n";
+import { createWidget } from "discourse/widgets/widget";
+import hbs from "discourse/widgets/hbs-compiler";
+import RawHtml from "discourse/widgets/raw-html";
+import { h } from "virtual-dom";
+
+const STATUS_NAMES = ["firing", "suppressed", "stale", "resolved"];
+const STATUS_EMOJIS = {
+  firing: "fire",
+  suppressed: "shushing_face"
+};
+
+const COLLAPSE_THRESHOLD = 30;
+
+createWidget("alert-receiver-data", {
+  tagName: "div",
+  buildClasses() {
+    return "cooked prometheus-alert-receiver";
+  },
+
+  html(attrs) {
+    const groupedByStatus = {};
+    const statusCounts = {};
+
+    attrs.alerts.forEach(a => {
+      if (!groupedByStatus[a.status]) {
+        groupedByStatus[a.status] = {};
+        statusCounts[a.status] = 0;
+      }
+      const groupedByDc = groupedByStatus[a.status];
+      if (!groupedByDc[a.datacenter]) {
+        groupedByDc[a.datacenter] = [];
+      }
+      groupedByDc[a.datacenter].push(a);
+      statusCounts[a.status] += 1;
+    });
+
+    const content = [];
+
+    STATUS_NAMES.forEach(statusName => {
+      const groupedByDc = groupedByStatus[statusName];
+      if (!groupedByDc) return;
+
+      const headerContent = [];
+      if (STATUS_EMOJIS[statusName]) {
+        headerContent.push(
+          this.attach("emoji", { name: STATUS_EMOJIS[statusName] })
+        );
+        headerContent.push(" ");
+      }
+      headerContent.push(I18n.t(`prom_alert_receiver.headers.${statusName}`));
+      content.push(h("h2", {}, headerContent));
+
+      const collapsed = statusCounts[statusName] > COLLAPSE_THRESHOLD;
+
+      Object.entries(groupedByDc).forEach(([dcName, alerts]) => {
+        const table = this.attach("alert-receiver-table", {
+          status: statusName,
+          alerts: alerts,
+          heading: dcName,
+          headingLink: alerts[0].external_url
+        });
+        let toAppend = table;
+
+        if (collapsed) {
+          toAppend = this.attach("alert-receiver-collapsible-table", {
+            alerts: alerts,
+            heading: dcName,
+            contents: () => {
+              return table;
+            }
+          });
+        }
+
+        content.push(toAppend);
+      });
+    });
+
+    return content;
+  }
+});
+
+createWidget("alert-receiver-date", {
+  tagName: "span.alert-receiver-date",
+  html(attrs) {
+    if (!attrs.timestamp) return;
+
+    const splitTimestamp = attrs.timestamp.split("T");
+    if (!splitTimestamp.length === 2) return;
+
+    const date = splitTimestamp[0];
+    const time = splitTimestamp[1];
+
+    const dateElement = document.createElement("span");
+    dateElement.className = "discourse-local-date";
+
+    const data = dateElement.dataset;
+
+    if (attrs.hideDate) {
+      data.format = "HH:mm";
+    } else {
+      data.format = "YYYY-MM-DD HH:mm";
+    }
+
+    data.displayedTimezone = "UTC";
+    data.date = date;
+    data.time = time;
+    data.timezone = "UTC";
+
+    dateElement.textContent = attrs.timestamp;
+
+    if ($().applyLocalDates) $(dateElement).applyLocalDates();
+
+    return new RawHtml({ html: dateElement.outerHTML });
+  }
+});
+
+createWidget("alert-receiver-date-range", {
+  tagName: "span",
+  html(attrs) {
+    const content = [];
+    if (!attrs.startsAt) return;
+
+    if (!attrs.endsAt) {
+      content.push("active since ");
+    }
+
+    content.push(
+      this.attach("alert-receiver-date", { timestamp: attrs.startsAt })
+    );
+
+    if (attrs.endsAt) {
+      content.push(" to ");
+      const startDate = attrs.startsAt.split("T")[0];
+      const endDate = attrs.endsAt.split("T")[0];
+
+      const hideDate = startDate === endDate;
+
+      content.push(
+        this.attach("alert-receiver-date", {
+          timestamp: attrs.endsAt,
+          hideDate
+        })
+      );
+    }
+
+    return content;
+  }
+});
+
+createWidget("alert-receiver-row", {
+  tagName: "tr",
+
+  transform(attrs) {
+    return {
+      logsUrl: this.buildLogsUrl(attrs),
+      graphUrl: this.buildGraphUrl(attrs),
+      grafanaUrl: this.buildGrafanaUrl(attrs)
+    };
+  },
+
+  buildLogsUrl(attrs) {
+    const base = attrs.alert.logs_url;
+    if (!base) return;
+    const start = attrs.alert.starts_at;
+    const end = attrs.alert.ends_at || new Date().toISOString();
+    return `${base}#/discover?_g=(time:(from:'${start}',mode:absolute,to:'${end}'))`;
+  },
+
+  buildGraphUrl(attrs) {
+    const base = attrs.alert.graph_url;
+    if (!base) return;
+    const url = new URL(base);
+
+    const start = new Date(attrs.alert.starts_at);
+    const end = attrs.alert.ends_at
+      ? new Date(attrs.alert.ends_at)
+      : new Date();
+
+    // Make the graph window 5 minutes either side of the alert
+    const windowDuration = (end - start) / 1000 + 600; // Add 10 minutes
+    const windowEndDate = new Date(end.getTime() + 300 * 1000); // Shift 5 minutes forward
+
+    url.searchParams.set("g0.range_input", `${windowDuration}s`);
+    url.searchParams.set("g0.end_input", windowEndDate.toISOString());
+    url.searchParams.set("g0.tab", "0");
+
+    return url.toString();
+  },
+
+  buildGrafanaUrl(attrs) {
+    const base = attrs.alert.grafana_url;
+    if (!base) return;
+    const url = new URL(base);
+
+    const start = new Date(attrs.alert.starts_at);
+
+    const end = attrs.alert.ends_at
+      ? new Date(attrs.alert.ends_at)
+      : new Date();
+
+    // Grafana uses milliseconds since epoch
+    url.searchParams.set("from", start.getTime());
+    url.searchParams.set("to", end.getTime());
+
+    return url.toString();
+  },
+
+  template: hbs`
+    <td><a href={{transformed.graphUrl}}>{{attrs.alert.id}}</a></td>
+    <td>
+      {{alert-receiver-date-range 
+          startsAt=attrs.alert.starts_at
+          endsAt=attrs.alert.ends_at
+        }}
+    </td>
+    {{#if attrs.showDescription}}
+      <td>{{attrs.alert.description}}</td>
+    {{/if}}
+    <td>
+      <div>
+        <a href={{transformed.logsUrl}}>{{emoji name='file_folder'}}</a>
+        {{#if transformed.grafanaUrl}}
+          <a href={{transformed.grafanaUrl}}>{{emoji name='bar_chart'}}</a>
+        {{/if}}
+      </div>
+    </td>
+  `
+});
+
+createWidget("alert-receiver-collapsible-table", {
+  tagName: "div.collapsible-table",
+
+  template: hbs`
+    <details>
+      <summary>{{attrs.heading}} ({{attrs.alerts.length}})</summary>
+      {{yield}}
+    </details>
+  `
+});
+
+createWidget("alert-receiver-table", {
+  tagName: "div",
+
+  buildClasses() {
+    return `md-table`;
+  },
+
+  buildAttributes(attrs) {
+    return {
+      "data-alert-status": attrs.status
+    };
+  },
+
+  transform(attrs) {
+    return {
+      showDescriptionColumn: attrs.alerts.any(a => a.description)
+    };
+  },
+
+  template: hbs`
+    <table class="prom-alerts-table">
+      <thead>
+        <tr>
+          <th><a href={{attrs.headingLink}}>{{attrs.heading}}</a></th>
+          <th></th>
+          {{#if transformed.showDescriptionColumn}}<th></th>{{/if}}
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>        
+        {{#each attrs.alerts as |alert|}}
+          {{alert-receiver-row alert=alert showDescription=this.transformed.showDescriptionColumn}}
+        {{/each}}
+      </tbody>
+    </table>
+  `
+});

--- a/assets/stylesheets/topic-post.scss
+++ b/assets/stylesheets/topic-post.scss
@@ -1,4 +1,5 @@
-[data-plugin="prom-alerts-table"] {
+[data-plugin="prom-alerts-table"],
+.prometheus-alert-receiver {
   table {
     position: relative;
   }
@@ -43,7 +44,7 @@
     }
   }
 
-  td:nth-child(2) > .discourse-local-date:nth-child(2) {
+  td:nth-child(2) .alert-receiver-date:nth-child(2) {
     .d-icon {
       display: none;
     }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1,5 +1,11 @@
 en:
   js:
+    prom_alert_receiver:
+      headers:
+        firing: "Firing Alerts"
+        resolved: "Alert History"
+        stale: "Stale Alerts"
+        suppressed: "Silenced Alerts"
     filters:
       alerts-category:
         title_with_count:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -5,14 +5,6 @@ en:
     prometheus_alert_receiver_enable_assign: "Enable the assignment of new alert topics based on the topic_assignee and group_topic_assignee annotations"
     prometheus_alert_receiver_debug_enabled: "Enable debugging for prometheus alert receiver"
   prom_alert_receiver:
-    post:
-      headers:
-        firing: "Firing Alerts"
-        history: "Alert History"
-        stale: "Stale Alerts"
-      more: 
-        one: +%{count} more
-        other: +%{count} more
     topic_title: 
       not_firing: "%{base_title}"
       firing: "%{base_title} (%{count} firing)"

--- a/spec/integration/discourse_prometheus_alert_receiver/receiver_controller_spec.rb
+++ b/spec/integration/discourse_prometheus_alert_receiver/receiver_controller_spec.rb
@@ -297,27 +297,6 @@ RSpec.describe DiscoursePrometheusAlertReceiver::ReceiverController do
               datacenter2
             )
 
-            raw = first_post.reload.raw
-
-            [
-              "# :shushing_face: Silenced Alerts",
-              "## #{I18n.t('prom_alert_receiver.post.headers.stale')}",
-            ].each do |content|
-              expect(raw).to include(content)
-            end
-
-            expect(raw).to match(
-              /somethingfunny.*date=2018-07-24 time=23:25:31/
-            )
-
-            expect(raw).to match(
-              /somethingnotfunny.*date=2018-07-24 time=23:25:31/
-            )
-
-            expect(raw).to match(
-              /doesnotexists.*date=2018-07-24 time=23:25:31/
-            )
-
             expect(
               topic.custom_fields[custom_field_key]['alerts'].first['description']
             ).to eq('some description')
@@ -421,27 +400,6 @@ RSpec.describe DiscoursePrometheusAlertReceiver::ReceiverController do
             expect(topic.tags.pluck(:name)).to contain_exactly(
               datacenter,
               datacenter2
-            )
-
-            raw = first_post.reload.raw
-
-            [
-              "# :shushing_face: Silenced Alerts",
-              "## #{I18n.t('prom_alert_receiver.post.headers.stale')}",
-            ].each do |content|
-              expect(raw).to include(content)
-            end
-
-            expect(raw).to match(
-              /somethingfunny.*date=2018-07-24 time=23:25:31/
-            )
-
-            expect(raw).to match(
-              /somethingnotfunny.*date=2018-07-24 time=23:25:31/
-            )
-
-            expect(raw).to match(
-              /doesnotexists.*date=2018-07-24 time=23:25:31/
             )
 
             expect(
@@ -635,23 +593,6 @@ RSpec.describe DiscoursePrometheusAlertReceiver::ReceiverController do
               datacenter2,
               "firing"
             )
-
-            raw = first_post.reload.raw
-
-            expect(raw).to_not include("# :shushing_face: Silenced Alerts")
-            expect(raw).to include("## #{I18n.t('prom_alert_receiver.post.headers.stale')}")
-
-            expect(raw).to match(
-              /somethingfunny.*date=2018-07-24 time=23:25:31/
-            )
-
-            expect(raw).to match(
-              /somethingnotfunny.*date=2018-07-24 time=23:25:31/
-            )
-
-            expect(raw).to match(
-              /doesnotexists.*date=2018-07-24 time=23:25:31/
-            )
           end
 
           it 'should not update the topic if nothing has changed' do
@@ -818,17 +759,6 @@ RSpec.describe DiscoursePrometheusAlertReceiver::ReceiverController do
           expect(raw).to include(
             "Test topic\.\.\. test topic\.\.\. whoop whoop"
           )
-
-          expect(raw).to include(<<~RAW)
-          | [#{datacenter}](#{external_url}) | | | |
-          | --- | --- | --- | --- |
-          RAW
-
-          expect(raw).to match(/somethingfunny.*date=2020-01-02 time=03:04:05/)
-
-          expect(raw).to match(
-            /http:\/\/alerts\.example\.com\/graph\?g0\.expr=lolrus.*g0\.tab=0/
-          )
         end
       end
 
@@ -858,18 +788,6 @@ RSpec.describe DiscoursePrometheusAlertReceiver::ReceiverController do
             datacenter,
             AlertPostMixin::FIRING_TAG,
             AlertPostMixin::HIGH_PRIORITY_TAG
-          )
-
-          raw = topic.posts.first.raw
-
-          expect(raw).to include(
-            "## :fire: #{I18n.t('prom_alert_receiver.post.headers.firing')}"
-          )
-
-          expect(raw).to include("some description")
-
-          expect(raw).to match(
-            /somethingfunny.*date=2020-01-02 time=03:04:05/
           )
         end
       end
@@ -969,28 +887,6 @@ RSpec.describe DiscoursePrometheusAlertReceiver::ReceiverController do
               }
             ]
           )
-
-          raw = topic.posts.first.raw
-
-          expect(raw).to include(
-            "## :fire: #{I18n.t("prom_alert_receiver.post.headers.firing")}"
-          )
-
-          expect(raw).to match(/somethingnotfunny.*date=2020-01-02 time=03:04:05/)
-
-          expect(raw).to include(
-            "## #{I18n.t("prom_alert_receiver.post.headers.history")}"
-          )
-
-          expect(raw).to match(/somethingfunny.*date=2020-01-02 time=09:08:07/)
-
-          expect(raw).to include(
-            "[:file_folder:](#{logs_url}#/discover?_g=(time:(from:'2020-01-02T03:04:05Z',mode:absolute,to:'2020-01-02T09:08:07Z')))"
-          )
-
-          expect(raw).to include(
-            "[:bar_chart:](http://graphs.example.com/d/xyzabcefg?from=1577934245000&to=1577956087000"
-          )
         end
       end
 
@@ -1081,11 +977,6 @@ RSpec.describe DiscoursePrometheusAlertReceiver::ReceiverController do
               },
             ]
           )
-
-          raw = topic.posts.first.raw
-
-          expect(raw).to match(/oldalert.*date=2020-01-02 time=03:04:05/)
-          expect(raw).to match(/newalert.*date=2020-12-31 time=23:59:59/)
         end
 
         it "bumps the existing topic correctly" do
@@ -1186,25 +1077,6 @@ RSpec.describe DiscoursePrometheusAlertReceiver::ReceiverController do
               ]
             )
 
-            raw = topic.posts.first.raw
-
-            expect(raw).to include(<<~RAW)
-            | [#{datacenter}](#{external_url}) | | |
-            | --- | --- | --- |
-            RAW
-
-            expect(raw).to include(<<~RAW)
-            | [#{datacenter2}](#{external_url2}) | | | |
-            | --- | --- | --- | --- |
-            RAW
-
-            expect(raw).to match(
-              /oldalert.*date=2020-01-02 time=03:04:05/
-            )
-
-            expect(raw).to match(
-              /oldalert.*date=2020-12-31 time=23:59:59/
-            )
           end
         end
       end
@@ -1439,16 +1311,6 @@ RSpec.describe DiscoursePrometheusAlertReceiver::ReceiverController do
 
             expect(topic.tags.pluck(:name)).to contain_exactly(
               datacenter, AlertPostMixin::HIGH_PRIORITY_TAG
-            )
-
-            raw = first_post.reload.raw
-
-            expect(raw).to include(
-              "## #{I18n.t('prom_alert_receiver.post.headers.history')}"
-            )
-
-            expect(raw).to match(
-              /somethingfunny.*date=2020-01-02 time=03:04:05.*date=2020-01-02 time=09:08:07/
             )
           end
         end

--- a/test/javascripts/acceptance/alert-receiver-test.js.es6
+++ b/test/javascripts/acceptance/alert-receiver-test.js.es6
@@ -1,0 +1,86 @@
+import { acceptance } from "helpers/qunit-helpers";
+import Fixtures from "fixtures/topic";
+
+function alertData(status, datacenter, id) {
+  const data = {
+    status,
+    id,
+    datacenter,
+    starts_at: "2020-07-27T17:26:49.526234411Z",
+    ends_at: null,
+    external_url: "http://alertmanager.example.com",
+    graph_url:
+      "https://metrics.sjc1.discourse.cloud/graph?g0.expr=mymetric&g0.tab=1",
+    logs_url: "http://kibana.example.com/app/kibana"
+  };
+
+  if (status === "resolved") {
+    data.ends_at = "2020-07-27T17:35:35.870002386Z";
+  }
+
+  return data;
+}
+
+acceptance("Alert Receiver", {
+  loggedIn: true,
+  mobileView: true,
+  pretend(server, helper) {
+    const json = Object.assign({}, Fixtures["/t/280/1.json"]);
+
+    json.alert_data = [
+      alertData("resolved", "sjc1", "myalert1"),
+      alertData("resolved", "sjc1", "myalert2"),
+      alertData("suppressed", "sjc1", "myalert3"),
+      alertData("stale", "sjc1", "myalert4"),
+      alertData("firing", "sjc1", "myalert5"),
+      alertData("firing", "sjc2", "myalert6")
+    ];
+
+    server.get("/t/281.json", () => {
+      return helper.response(json);
+    });
+  }
+});
+
+QUnit.test("displays all the alerts", async assert => {
+  await visit("/t/internationalization-localization/281");
+  assert.ok(
+    exists(".prometheus-alert-receiver"),
+    "the prometheus data is visible"
+  );
+
+  const alertNames = find(".prometheus-alert-receiver")[0].querySelectorAll(
+    "table tr td:first-child"
+  );
+  assert.deepEqual(
+    Array.from(alertNames)
+      .map(e => e.innerText)
+      .sort(),
+    ["myalert1", "myalert2", "myalert3", "myalert4", "myalert5", "myalert6"],
+    "the alerts are all visible"
+  );
+
+  assert.equal(
+    find(".prometheus-alert-receiver table thead th:first-child a").attr(
+      "href"
+    ),
+    "http://alertmanager.example.com",
+    "links the per-dc header to the alertmanager"
+  );
+
+  assert.equal(
+    find(
+      ".prometheus-alert-receiver [data-alert-status='resolved'] table tr td:first-child a"
+    ).attr("href"),
+    "https://metrics.sjc1.discourse.cloud/graph?g0.expr=mymetric&g0.tab=0&g0.range_input=1126.344s&g0.end_input=2020-07-27T17%3A40%3A35.870Z",
+    "links each alert to its graph, with added timestamp"
+  );
+
+  assert.equal(
+    find(
+      ".prometheus-alert-receiver [data-alert-status='resolved'] table tr td:last-child a"
+    ).attr("href"),
+    "http://kibana.example.com/app/kibana#/discover?_g=(time:(from:'2020-07-27T17:26:49.526234411Z',mode:absolute,to:'2020-07-27T17:35:35.870002386Z'))",
+    "adds a log link, with correct timestamps"
+  );
+});


### PR DESCRIPTION
This commit changes from rendering alerts in post markdown to rendering them directly in the JS app. This means that updating the database with incoming alert data is much cheaper, and also gives us the flexibility to improve the alert UI in future without being restricted by markdown.