### PR TITLE
REFACTOR: Use a dedicated table for storing alert data

### DIFF
--- a/app/controllers/discourse_prometheus_alert_receiver/receiver_controller.rb
+++ b/app/controllers/discourse_prometheus_alert_receiver/receiver_controller.rb
@@ -74,7 +74,8 @@ module DiscoursePrometheusAlertReceiver
         data: params[:data].to_json,
         graph_url: params[:graphURL],
         logs_url: params[:logsURL],
-        grafana_url: params[:grafanaURL]
+        grafana_url: params[:grafanaURL],
+        external_url: params[:externalURL]
       )
 
       render json: success_json

--- a/app/jobs/concerns/alert_post_mixin.rb
+++ b/app/jobs/concerns/alert_post_mixin.rb
@@ -7,44 +7,60 @@ module AlertPostMixin
   HIGH_PRIORITY_TAG = "high-priority".freeze
   NEXT_BUSINESS_DAY_SLA = "nbd".freeze
 
+  MAX_BUMP_RATE = 5.minutes
+
+  PREVIOUS_TOPIC = DiscoursePrometheusAlertReceiver::PREVIOUS_TOPIC_CUSTOM_FIELD
+  TOPIC_BODY = DiscoursePrometheusAlertReceiver::TOPIC_BODY_CUSTOM_FIELD
+  BASE_TITLE = DiscoursePrometheusAlertReceiver::TOPIC_BASE_TITLE_CUSTOM_FIELD
+
   private
 
-  def local_date(time, starts_at = nil)
-    parsed = Time.zone.parse(time)
-    format = "L HH:mm"
+  def parse_alerts(raw_alerts, external_url:, logs_url: nil, grafana_url: nil)
+    raw_alerts.map do |raw_alert|
+      alert = {
+        external_url: external_url,
+        alertname: raw_alert['labels']['alertname'],
+        datacenter: raw_alert["labels"]["datacenter"],
+        identifier: raw_alert['labels']['id'],
+        status: normalize_status(raw_alert['status']),
+        starts_at: raw_alert['startsAt'],
+        ends_at: raw_alert['status'] == 'firing' ? nil : raw_alert['endsAt'],
+        graph_url: raw_alert['generatorURL'],
+        description: raw_alert.dig('annotations', 'description'),
+        logs_url: logs_url
+      }
 
-    if starts_at.present?
-      from = Time.zone.parse(starts_at)
-      format = "HH:mm" if from.at_beginning_of_day == parsed.at_beginning_of_day
+      if dashboard_path = raw_alert.dig('annotations', 'grafana_dashboard_path')
+        alert[:grafana_url] = "#{grafana_url}#{dashboard_path}"
+      end
+
+      alert[:ends_at] = nil if alert['status'] != 'resolved'
+
+      alert
     end
-
-    date = +<<~DATE
-    [date=#{parsed.strftime("%Y-%m-%d")} time=#{parsed.strftime("%H:%M:%S")} format="#{format}" displayedTimezone="UTC" timezones="Europe/Paris\\|America/Los_Angeles\\|Asia/Singapore\\|Australia/Sydney"]
-    DATE
-
-    date.chomp!
-    date
   end
 
-  def get_grafana_dashboard_url(alert, grafana_url)
-    return if alert.blank? || grafana_url.blank?
+  def normalize_status(status)
+    status = status['state'] if status.is_a?(Hash)
+    return "firing" if status == "active"
+    status
+  end
 
-    dashboard_path = alert.dig('annotations', 'grafana_dashboard_path')
-    return if dashboard_path.blank?
+  def local_date(time)
+    parsed = Time.zone.parse(time)
 
-    "#{grafana_url}#{dashboard_path}"
+    <<~DATE.chomp
+      [date=#{parsed.strftime("%Y-%m-%d")} time=#{parsed.strftime("%H:%M:%S")} format="YYYY-MM-DD HH:mm" displayedTimezone="UTC"]
+    DATE
   end
 
   def prev_topic_link(topic_id)
     return "" if topic_id.nil?
-    created_at = Topic.where(id: topic_id).pluck(:created_at).first
-    return "" unless created_at
-
+    return "" unless created_at = Topic.where(id: topic_id).pluck_first(:created_at)
     "[Previous alert](#{Discourse.base_url}/t/#{topic_id}) #{local_date(created_at.to_s)}\n\n"
   end
 
-  def generate_title(base_title, alert_history)
-    firing_count = alert_history&.count { |alert| is_firing?(alert["status"]) }
+  def generate_title(base_title, firing_count)
     if firing_count > 0
       I18n.t("prom_alert_receiver.topic_title.firing", base_title: base_title, count: firing_count)
     else
@@ -52,68 +68,73 @@ module AlertPostMixin
     end
   end
 
-  def first_post_body(receiver:,
-                      topic_body: "",
-                      alert_history:,
-                      prev_topic_id:)
-
-    output = ""
-    output += "#{topic_body}\n\n"
-    output += "#{prev_topic_link(prev_topic_id)}\n\n" if prev_topic_id
-
+  def first_post_body(topic_body: "", prev_topic_id:)
+    output = "#{topic_body}"
+    output += "\n\n#{prev_topic_link(prev_topic_id)}" if prev_topic_id
     output
   end
 
-  def revise_topic(topic:, title:, raw:, datacenters:, firing: nil, high_priority: false)
-    post = topic.first_post
+  def revise_topic(topic:, high_priority: false)
+    firing_count = topic.alert_receiver_alerts.firing.count
+    firing = firing_count > 0
+
+    title = generate_title(
+      topic.custom_fields[BASE_TITLE],
+      firing_count
+    )
+
+    raw = first_post_body(
+      topic_body: topic.custom_fields[TOPIC_BODY],
+      prev_topic_id: topic.custom_fields[PREVIOUS_TOPIC]
+    )
+
+    datacenters = topic.alert_receiver_alerts.distinct.pluck(:datacenter).compact
+
+    existing_tags = topic.tags.pluck(:name)
+    new_tags = existing_tags
+
+    new_tags.concat(datacenters)
+    new_tags << HIGH_PRIORITY_TAG.dup if high_priority
+
+    if firing
+      new_tags << FIRING_TAG.dup
+    else
+      new_tags.delete(FIRING_TAG)
+    end
+
+    tags_changed = new_tags.uniq != existing_tags
     title_changed = topic.title != title
-    skip_revision = true
+    raw_changed = topic.first_post.raw != raw
 
-    if post.raw.strip != raw.strip || title_changed || !firing.nil?
-      post = topic.first_post
-
-      fields = {
-        title: title,
-        raw: raw
-      }
-
-      fields[:tags] ||= []
-
-      if datacenters.present?
-        fields[:tags] = topic.tags.pluck(:name)
-        fields[:tags].concat(datacenters)
-        fields[:tags].uniq!
-      end
-
-      fields[:tags] << HIGH_PRIORITY_TAG.dup if high_priority
-
-      if firing
-        fields[:tags] << FIRING_TAG.dup
-      else
-        fields[:tags].delete(FIRING_TAG)
-      end
-
-      PostRevisor.new(post, topic).revise!(
+    if raw_changed || title_changed || tags_changed
+      PostRevisor.new(topic.first_post, topic).revise!(
         Discourse.system_user,
-        fields,
-        skip_revision: skip_revision,
+        {
+          title: title,
+          raw: raw,
+          tags: new_tags
+        },
+        skip_revision: true,
         skip_validations: true,
         validate_topic: true # This is a very weird API
       )
-      if firing && title_changed
+
+      if firing && title_changed && topic.bumped_at < MAX_BUMP_RATE.ago
+        # Articifically bump the topic
         topic.update_column(:bumped_at, Time.now)
         TopicTrackingState.publish_latest(topic)
       end
+    else
+      # The topic hasn't changed
+      # The alert data has changed, so notify clients to reload
+      topic.first_post.publish_change_to_clients(:revised, reload_topic: true)
     end
   end
 
-  def is_firing?(status)
-    status == "firing".freeze
-  end
-
-  def datacenters(alerts)
-    alerts.each_with_object(Set.new) do |alert, set|
-      set << alert['datacenter'] if alert['datacenter']
-    end.to_a
+  def publish_alert_counts
+    MessageBus.publish("/alert-receiver",
+      firing_alerts_count: Topic.firing_alerts.count,
+      open_alerts_count: Topic.open_alerts.count
+    )
   end
 end

--- a/app/jobs/regular/process_grouped_alerts.rb
+++ b/app/jobs/regular/process_grouped_alerts.rb
@@ -6,8 +6,8 @@ module Jobs
 
     include AlertPostMixin
 
-    STALE_DURATION = 5.freeze
-
+    # Processes data from {{alertmanager}}/api/v1/alerts
+    # Sent by discourse/prometheus-alertmanager-webhooks
     def execute(args)
       token = args[:token]
       data = JSON.parse(args[:data])
@@ -17,109 +17,30 @@ module Jobs
         token
       )
 
-      if data[0]&.key?("blocks")
-        # Data from {{alertmanager}}/api/v1/alerts/grouped (removed in alertmanager v0.16.0)
-        current_alerts = current_alerts(data)
-      else
-        # Data from {{alertmanager}}/api/v1/alerts
-        current_alerts = data
-      end
+      parsed_alerts = parse_alerts(data, **args.symbolize_keys.slice(:logs_url, :grafana_url, :external_url))
 
-      update_open_alerts(receiver, current_alerts, args.slice(:graph_url, :logs_url, :grafana_url))
+      update_open_alerts(receiver, parsed_alerts, **args.symbolize_keys.slice(:external_url))
     end
 
     private
 
-    def alert_history_key
-      DiscoursePrometheusAlertReceiver::ALERT_HISTORY_CUSTOM_FIELD
-    end
+    def update_open_alerts(receiver, parsed_alerts, external_url:)
+      parsed_alerts.each { |a| a[:topic_id] = receiver[:topic_map][a[:alertname]] }
+        .reject! { |a| a[:topic_id].nil? }
 
-    def current_alerts(data)
-      @current_alerts ||= begin
-        alerts = []
+      updated_topic_ids = AlertReceiverAlert.update_alerts(parsed_alerts, mark_stale_external_url: external_url)
 
-        data.each do |group|
-          group["blocks"].each do |block|
-            alerts.concat(block["alerts"])
-          end
-        end
+      return if updated_topic_ids.blank?
 
-        alerts
-      end
-    end
-
-    def normalize_status(status)
-      return "firing" if status == "active"
-      status
-    end
-
-    def update_open_alerts(receiver, active_alerts, opts)
-      Topic.open_alerts.each do |topic|
+      Topic.where(id: updated_topic_ids).each do |topic|
         DistributedMutex.synchronize("prom_alert_receiver_topic_#{topic.id}") do
           alertname = receiver["topic_map"].key(topic.id)
-          next unless alertname
-
-          stored_alerts = topic.custom_fields.dig(alert_history_key, 'alerts')
-          updated = false
-
-          stored_alerts&.each do |stored_alert|
-            stored_alert['logs_url'] ||= opts[:logs_url] if opts[:logs_url].present?
-
-            if stored_alert['graph_url'].include?(opts[:graph_url]) && stored_alert['status'] != 'resolved'
-              active_alert = active_alerts.find { |a| a['labels']['id'] == stored_alert['id'] && a['labels']['alertname'] == alertname }
-
-              grafana_dashboard_url = get_grafana_dashboard_url(active_alert, opts[:grafana_url])
-              stored_alert['grafana_url'] = grafana_dashboard_url if grafana_dashboard_url.present?
-
-              if !active_alert && stored_alert["status"] != "stale" &&
-                  STALE_DURATION.minute.ago > DateTime.parse(stored_alert["starts_at"])
-                stored_alert["status"] = "stale"
-                updated = true
-              elsif active_alert && stored_alert["status"] != normalize_status(active_alert["status"]["state"])
-                stored_alert["status"] = normalize_status(active_alert["status"]["state"])
-                stored_alert["description"] = active_alert.dig("annotations", "description")
-                updated = true
-              end
-            end
-          end
-
-          if updated
-            topic.custom_fields[::DiscoursePrometheusAlertReceiver::ALERT_HISTORY_VERSION_CUSTOM_FIELD] = 2
-            topic.save_custom_fields(true)
-            klass = DiscoursePrometheusAlertReceiver
-
-            if base_title = topic.custom_fields[klass::TOPIC_BASE_TITLE_CUSTOM_FIELD]
-              title = generate_title(base_title, stored_alerts)
-            else
-              title = topic.custom_fields[klass::TOPIC_TITLE_CUSTOM_FIELD] || ''
-            end
-
-            raw = first_post_body(
-              receiver: receiver,
-              topic_body: topic.custom_fields[klass::TOPIC_BODY_CUSTOM_FIELD] || '',
-              alert_history: stored_alerts,
-              prev_topic_id: topic.custom_fields[klass::PREVIOUS_TOPIC_CUSTOM_FIELD]
-            )
-
-            revise_topic(
-              topic: topic,
-              title: title,
-              raw: raw,
-              datacenters: datacenters(stored_alerts),
-              firing: stored_alerts.any? { |alert| is_firing?(alert["status"]) }
-            )
-
-            publish_alert_counts
-          end
+          revise_topic(topic: topic) if alertname
         end
       end
+
+      publish_alert_counts
     end
 
-    def publish_alert_counts
-      MessageBus.publish("/alert-receiver",
-        firing_alerts_count: Topic.firing_alerts.count,
-        open_alerts_count: Topic.open_alerts.count
-      )
-    end
   end
 end

--- a/app/models/alert_receiver_alert.rb
+++ b/app/models/alert_receiver_alert.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+class AlertReceiverAlert < ActiveRecord::Base
+  STALE_DURATION = 5.minutes
+
+  belongs_to :topic
+
+  scope :firing, -> { where(status: 'firing') }
+  scope :stale, -> { where(status: 'stale') }
+
+  def self.update_resolved(alerts)
+    return [] unless alerts.present?
+
+    value_columns = ['topic_id', 'external_url', 'identifier', 'ends_at']
+
+    values_array = alerts.pluck(*value_columns.map(&:to_sym))
+    values_hash = Hash[values_array.each_with_index.map { |v, i| [:"value#{i}", v] }]
+
+    values_string = values_hash.keys.map { |key| "(:#{key})" }.join(',')
+
+    query = <<~SQL
+      UPDATE alert_receiver_alerts alerts
+      SET status='resolved', ends_at=data.ends_at::timestamp
+      FROM (values #{values_string})
+        AS data(topic_id, external_url, identifier, ends_at)
+      WHERE alerts.topic_id = data.topic_id
+        AND alerts.external_url = data.external_url
+        AND alerts.identifier = data.identifier
+        AND (alerts.status IN ('firing', 'suppressed'))
+      RETURNING alerts.topic_id
+    SQL
+
+    topic_ids = DB.query_single(query, values_hash)
+
+    topic_ids.uniq
+  end
+
+  def self.update_active(alerts)
+    return [] unless alerts.present?
+
+    insert_columns = column_names - ['id']
+    update_columns = insert_columns - ['topic_id', 'identifier', 'starts_at', 'external_url']
+
+    array_to_insert = alerts.pluck(*insert_columns.map(&:to_sym))
+    hash_to_insert = Hash[array_to_insert.each_with_index.map { |v, i| [:"value#{i}", v] }]
+
+    insert_columns_string = insert_columns.map { |c| "\"#{c}\"" }.join(',')
+    values_string = hash_to_insert.keys.map { |key| "(:#{key})" }.join(',')
+    set_string = update_columns.map { |c| "\"#{c}\"=excluded.\"#{c}\"" }.join(',')
+    where_string = update_columns.map { |c| "#{table_name}.\"#{c}\" IS DISTINCT FROM excluded.\"#{c}\"" }.join(' OR ')
+
+    query = <<~SQL
+      INSERT INTO "#{table_name}" (#{insert_columns_string})
+      VALUES #{values_string}
+      ON CONFLICT ("topic_id","external_url","identifier")
+        WHERE "status" in ('firing', 'suppressed')
+      DO UPDATE
+        SET #{set_string}
+        WHERE #{where_string}
+      RETURNING topic_id
+    SQL
+
+    topic_ids = DB.query_single query, hash_to_insert
+
+    topic_ids.uniq
+  end
+
+  def self.mark_stale(external_url: , active_alerts:)
+    value_columns = ['topic_id', 'identifier']
+
+    values_array = active_alerts.pluck(*value_columns.map(&:to_sym))
+    values_array << [nil, nil] if values_array.empty?
+    values_hash = Hash[values_array.each_with_index.map { |v, i| [:"value#{i}", v] }]
+
+    values_string = values_hash.keys.map { |key| "(:#{key})" }.join(',')
+
+    query = <<~SQL
+      WITH active_alerts(topic_id, identifier) AS (
+        VALUES #{values_string}
+      ),
+      stale_alerts AS (
+        SELECT id FROM alert_receiver_alerts db_alerts
+        WHERE NOT EXISTS (
+          SELECT 1 FROM active_alerts
+          WHERE db_alerts.topic_id = active_alerts.topic_id::integer
+            AND db_alerts.identifier = active_alerts.identifier
+        )
+        AND db_alerts.external_url = :external_url
+        AND db_alerts.status IN ('firing', 'suppressed')
+        AND db_alerts.starts_at < :stale_threshold
+      )
+      UPDATE alert_receiver_alerts alerts
+      SET status='stale'
+      FROM stale_alerts
+      WHERE stale_alerts.id = alerts.id
+      RETURNING alerts.topic_id
+    SQL
+
+    topic_ids = DB.query_single(
+                  query,
+                  values_hash.merge(
+                    external_url: external_url,
+                    stale_threshold: STALE_DURATION.ago
+                  )
+                )
+
+    topic_ids.uniq
+  end
+
+  def self.update_alerts(alerts, mark_stale_external_url: nil)
+    groups = alerts.group_by { |a| a[:status] }
+    active = [*groups['firing'], *groups['suppressed']]
+
+    topic_ids = self.update_active(active)
+    topic_ids += self.update_resolved(groups['resolved'])
+
+    if mark_stale_external_url
+      topic_ids += self.mark_stale(active_alerts: active, external_url: mark_stale_external_url)
+    end
+
+    topic_ids.uniq
+  end
+end

--- a/app/serializers/alert_receiver_alert.rb
+++ b/app/serializers/alert_receiver_alert.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AlertReceiverAlertSerializer < ApplicationSerializer
+  attributes :identifier,
+            :status,
+            :datacenter,
+            :description,
+            :starts_at,
+            :ends_at,
+            :external_url,
+            :graph_url,
+            :logs_url,
+            :grafana_url
+end

--- a/assets/javascripts/discourse/widgets/alert-receiver.js.es6
+++ b/assets/javascripts/discourse/widgets/alert-receiver.js.es6
@@ -207,7 +207,7 @@ createWidget("alert-receiver-row", {
   },
 
   template: hbs`
-    <td><a href={{transformed.graphUrl}}>{{attrs.alert.id}}</a></td>
+    <td><a href={{transformed.graphUrl}}>{{attrs.alert.identifier}}</a></td>
     <td>
       {{alert-receiver-date-range 
           startsAt=attrs.alert.starts_at

--- a/db/migrate/20200806144401_create_alert_receiver_alerts.rb
+++ b/db/migrate/20200806144401_create_alert_receiver_alerts.rb
@@ -1,0 +1,80 @@
+
+# frozen_string_literal: true
+class CreateAlertReceiverAlerts < ActiveRecord::Migration[6.0]
+  def change
+    create_table :alert_receiver_alerts do |t|
+      t.integer :topic_id, null: false
+
+      t.string :status, null: false
+      t.string :identifier
+      t.string :description
+      t.string :datacenter
+
+      t.datetime :starts_at, null: false
+      t.datetime :ends_at
+
+      t.string :external_url, null: false
+      t.string :graph_url
+      t.string :logs_url
+      t.string :grafana_url
+    end
+
+    add_index :alert_receiver_alerts, :topic_id
+    add_index :alert_receiver_alerts, [:topic_id, :external_url, :identifier],
+                  where: "status in ('firing', 'suppressed')",
+                  unique: true,
+                  name: :index_alert_receiver_alerts_unique_active
+
+    reversible do |dir|
+      dir.up do
+        # This migrates existing topic_custom_field data to the new table
+        # We only migrate topics which are currently open, or are using prom_alert_history_version=2
+        # Older topics used to store the alert data in markdown, so there is no need to migrate the
+        # raw data to the new format
+        execute <<~SQL
+          INSERT INTO alert_receiver_alerts
+          (
+            topic_id,
+            identifier,
+            description,
+            status,
+            datacenter,
+            starts_at,
+            ends_at,
+            external_url,
+            graph_url,
+            logs_url,
+            grafana_url
+          )
+          SELECT
+            tcf.topic_id,
+            a.*
+          FROM
+            topic_custom_fields tcf
+          CROSS JOIN LATERAL
+            json_to_recordset(tcf.value::json->'alerts') AS
+              a(id varchar,
+                description varchar,
+                status varchar,
+                datacenter varchar,
+
+                starts_at timestamp,
+                ends_at timestamp,
+
+                external_url varchar,
+                graph_url varchar,
+                logs_url varchar,
+                grafana_url varchar
+              )
+          JOIN topics on topics.id = tcf.topic_id
+          LEFT JOIN topic_custom_fields tcf_version
+            ON tcf.topic_id = tcf_version.topic_id
+            AND tcf_version.name = 'prom_alert_history_version'
+          WHERE tcf.name = 'prom_alert_history'
+          AND (tcf_version.value::integer = 2 OR (topics.deleted_at IS NULL AND NOT topics.closed))
+          AND json_typeof(tcf.value::json->'alerts') = 'array'
+        SQL
+      end
+    end
+  end
+end

--- a/spec/lib/topic_query_spec.rb
+++ b/spec/lib/topic_query_spec.rb
@@ -6,10 +6,6 @@ RSpec.describe TopicQuery do
   let(:user) { Fabricate(:user) }
   let(:category) { Fabricate(:category, name: 'alerts') }
 
-  let(:custom_field_key) do
-    DiscoursePrometheusAlertReceiver::ALERT_HISTORY_CUSTOM_FIELD
-  end
-
   describe '#list_latest' do
     it 'should return the right topics' do
       topic1 = Fabricate(:topic, category: category)
@@ -19,18 +15,13 @@ RSpec.describe TopicQuery do
         topic1 => 'firing',
         topic2 => 'resolved',
       }.each do |topic, status|
-        topic.custom_fields[custom_field_key] = {
-          'alerts' => [
-            {
-              'id' => 'somethingfunny',
-              'starts_at' => "2020-01-02T03:04:05.12345678Z",
-              'graph_url' => "http://alerts.example.com/graph?g0.expr=lolrus",
-              'status' => status
-            }
-          ]
-        }
-
-        topic.save_custom_fields(true)
+        topic.alert_receiver_alerts.create!(
+          identifier: 'somethingfunny',
+          starts_at: "2020-01-02T03:04:05.12345678Z",
+          graph_url: "http://graphs.example.com/graph?g0.expr=lolrus",
+          external_url: "http://alerts.example.com",
+          status: status
+        )
       end
 
       topic_query = TopicQuery.new(user,

--- a/spec/model/alert_receiver_alert_spec.rb
+++ b/spec/model/alert_receiver_alert_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe 'alert_receiver_alert' do
+  fab!(:topic1) { Fabricate(:topic) }
+  fab!(:topic2) { Fabricate(:topic) }
+
+  def alert(args)
+    dc = args[:datacenter] || "dc"
+    {
+      topic_id: topic1.id,
+      external_url: "alerts.#{dc}.example.com",
+      datacenter: dc,
+      identifier: 'myid',
+      status: 'firing',
+      starts_at: "2020-08-07T10:15:30.8467664Z",
+      ends_at: nil
+    }.merge(args)
+  end
+
+  it "can add firing alerts and resolve/suppress them" do
+    AlertReceiverAlert.update_alerts([
+      alert(identifier: 'myid1'),
+      alert(identifier: 'myid2'),
+      alert(identifier: 'myid1', datacenter: "dc2"),
+      alert(identifier: 'myid2', datacenter: "dc2")
+    ])
+
+    expect(AlertReceiverAlert.count).to eq(4)
+    expect(AlertReceiverAlert.firing.count).to eq(4)
+
+    AlertReceiverAlert.update_alerts([
+      alert(identifier: 'myid1', status: 'suppressed'),
+      alert(identifier: 'myid2', status: 'resolved'),
+      alert(identifier: 'myid1', datacenter: "dc2", status: 'suppressed'),
+      alert(identifier: 'myid2', datacenter: "dc2", status: 'resolved')
+    ])
+
+    expect(AlertReceiverAlert.count).to eq(4)
+    expect(AlertReceiverAlert.firing.count).to eq(0)
+  end
+
+  it "can return modified topic ids" do
+    topic_ids = AlertReceiverAlert.update_alerts([
+      alert(identifier: 'myid1'),
+      alert(identifier: 'myid2'),
+      alert(identifier: 'myid1', datacenter: "dc2"),
+      alert(identifier: 'myid2', datacenter: "dc2")
+    ])
+    expect(topic_ids).to eq([topic1.id])
+
+    topic_ids = AlertReceiverAlert.update_alerts([
+      alert(identifier: 'myid1'),
+      alert(identifier: 'myid2'),
+      alert(identifier: 'myid1', datacenter: "dc2"),
+      alert(identifier: 'myid2', datacenter: "dc2")
+    ])
+    expect(topic_ids).to eq([])
+
+    topic_ids = AlertReceiverAlert.update_alerts([
+      alert(identifier: 'myid1'),
+      alert(identifier: 'myid2'),
+      alert(identifier: 'myid1', datacenter: "dc2", description: "mydescription"),
+      alert(identifier: 'myid2', datacenter: "dc2")
+    ])
+    expect(topic_ids).to eq([topic1.id])
+
+    topic_ids = AlertReceiverAlert.update_alerts([
+      alert(identifier: 'myid1', status: 'suppressed'),
+      alert(identifier: 'myid2'),
+      alert(identifier: 'myid1', datacenter: "dc2", description: "mydescription"),
+      alert(identifier: 'myid2', datacenter: "dc2")
+    ])
+    expect(topic_ids).to eq([topic1.id])
+
+    topic_ids = AlertReceiverAlert.update_alerts([
+      alert(identifier: 'myid1', status: 'suppressed'),
+      alert(identifier: 'myid2'),
+      alert(identifier: 'myid1', datacenter: "dc2", description: "mydescription"),
+      alert(identifier: 'myid2', datacenter: "dc2", status: 'resolved')
+    ])
+    expect(topic_ids).to eq([topic1.id])
+  end
+
+  it "can mark stale correctly" do
+    AlertReceiverAlert.update_alerts([
+      alert(identifier: 'myid1'),
+      alert(identifier: 'myid2'),
+      alert(identifier: 'myid1', datacenter: "dc2"),
+      alert(identifier: 'myid2', datacenter: "dc2")
+    ])
+
+    expect(AlertReceiverAlert.count).to eq(4)
+    expect(AlertReceiverAlert.firing.count).to eq(4)
+
+    AlertReceiverAlert.update_alerts([
+      alert(identifier: 'myid2')
+    ], mark_stale_external_url: "alerts.dc.example.com")
+
+    expect(AlertReceiverAlert.count).to eq(4)
+    expect(AlertReceiverAlert.firing.count).to eq(3)
+    expect(AlertReceiverAlert.stale.count).to eq(1)
+  end
+end

--- a/spec/serializers/site_serializer_spec.rb
+++ b/spec/serializers/site_serializer_spec.rb
@@ -3,10 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe SiteSerializer do
-  let(:custom_field_key) do
-    DiscoursePrometheusAlertReceiver::ALERT_HISTORY_CUSTOM_FIELD
-  end
-
   describe '#firing_alerts' do
     let(:json) do
       site = Site.new(guardian)
@@ -25,18 +21,13 @@ RSpec.describe SiteSerializer do
         topic2 => 'resolved',
         topic3 => 'firing'
       }.each do |topic, status|
-        topic.custom_fields[custom_field_key] = {
-          'alerts' => [
-            {
-              'id' => 'somethingfunny',
-              'starts_at' => "2020-01-02T03:04:05.12345678Z",
-              'graph_url' => "http://alerts.example.com/graph?g0.expr=lolrus",
-              'status' => status
-            }
-          ]
-        }
-
-        topic.save_custom_fields(true)
+        topic.alert_receiver_alerts.create!(
+              identifier: 'somethingfunny',
+              starts_at: "2020-01-02T03:04:05.12345678Z",
+              graph_url: "http://alerts.example.com/graph?g0.expr=lolrus",
+              status: status,
+              external_url: "alerts.example.com"
+        )
       end
     end
 

--- a/test/javascripts/acceptance/alert-receiver-test.js.es6
+++ b/test/javascripts/acceptance/alert-receiver-test.js.es6
@@ -4,7 +4,7 @@ import Fixtures from "fixtures/topic";
 function alertData(status, datacenter, id) {
   const data = {
     status,
-    id,
+    identifier: id,
     datacenter,
     starts_at: "2020-07-27T17:26:49.526234411Z",
     ends_at: null,


### PR DESCRIPTION
This provides a few important benefits over JSON blobs:
- Alert data has a fixed schema
- We can query it more efficiently
- We can update it using upsert queries

A migration is included for currently open alert topics. Closed topics will only be migrated if they are using client-side rendering.