### PR TITLE
FEATURE: Introduce support for topic_tags annotation

### DIFF
--- a/app/jobs/concerns/alert_post_mixin.rb
+++ b/app/jobs/concerns/alert_post_mixin.rb
@@ -72,7 +72,7 @@ module AlertPostMixin
     output
   end
 
-  def revise_topic(topic:, high_priority: false)
+  def revise_topic(topic:, ensure_tags: [])
     firing_count = topic.alert_receiver_alerts.firing.count
     firing = firing_count > 0
 
@@ -89,13 +89,10 @@ module AlertPostMixin
     datacenters = topic.alert_receiver_alerts.distinct.pluck(:datacenter).compact
 
     existing_tags = topic.tags.pluck(:name)
-    new_tags = existing_tags
-
-    new_tags.concat(datacenters)
-    new_tags << HIGH_PRIORITY_TAG.dup if high_priority
+    new_tags = existing_tags | ensure_tags | datacenters
 
     if firing
-      new_tags << FIRING_TAG.dup
+      new_tags << FIRING_TAG
     else
       new_tags.delete(FIRING_TAG)
     end

--- a/spec/integration/discourse_prometheus_alert_receiver/receiver_controller_spec.rb
+++ b/spec/integration/discourse_prometheus_alert_receiver/receiver_controller_spec.rb
@@ -556,6 +556,25 @@ RSpec.describe DiscoursePrometheusAlertReceiver::ReceiverController do
         end
       end
 
+      context "an alert with topic_tags" do
+        let(:topic) { Fabricate(:post).topic }
+        let(:topic_map) { { alert_name => topic.id } }
+
+        before do
+          payload["commonAnnotations"]["topic_tags"] = "tag1,tag2"
+        end
+
+        it "should update the topic" do
+          freeze_time Time.now.utc
+
+          expect do
+            post "/prometheus/receiver/#{token}", params: payload
+          end.to change { AlertReceiverAlert.count }.by(1)
+
+          expect(topic.tags.pluck(:name)).to include('tag1', 'tag2')
+        end
+      end
+
       context "a resolving alert for a closed alert" do
         before do
           topic.alert_receiver_alerts.create!(


### PR DESCRIPTION
topic_tags is an optional, comma separated, list of Discourse tags which will be added to the alert topic