### PR TITLE
FIX: Only include alert_data in topic_view when it exists

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -105,7 +105,7 @@ after_initialize do
   end
 
   add_to_serializer(:topic_view, :include_alert_data?) do
-    alert_data.present?
+    object.topic.alert_receiver_alerts.present?
   end
 
   on(:after_extract_linked_users) do |users, post|


### PR DESCRIPTION
`alert_data.present?` is always true, because it's an instance of `ActiveModel::ArraySerializer`