### PR TITLE
PERF: Add partial index for alert topics.

### DIFF
--- a/app/jobs/regular/create_alert_topics_index.rb
+++ b/app/jobs/regular/create_alert_topics_index.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Jobs
+  class CreateAlertTopicsIndex < ::Jobs::Base
+    ALERT_TOPICS_INDEX_NAME = 'idx_alert_topics'
+
+    def execute(_)
+      DB.exec(<<~SQL)
+      DROP INDEX IF EXISTS #{ALERT_TOPICS_INDEX_NAME};
+      SQL
+
+      if (category_ids = Topic.alerts_category_ids).present?
+        DB.exec(<<~SQL)
+        CREATE INDEX #{Rails.env.test? ? '' : 'CONCURRENTLY'} #{ALERT_TOPICS_INDEX_NAME}
+        ON topics (id) WHERE deleted_at IS NULL AND NOT closed AND category_id IN (#{category_ids.join(",")})
+        SQL
+      end
+    end
+  end
+end

--- a/db/migrate/20210608034155_add_alert_topics_index.rb
+++ b/db/migrate/20210608034155_add_alert_topics_index.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class AddAlertTopicsIndex < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def up
+    category_ids = DB.query_single(<<~SQL)
+    SELECT
+      value::json->'category_id'
+    FROM plugin_store_rows
+    WHERE plugin_name = 'discourse-prometheus-alert-receiver'
+    SQL
+
+    if category_ids.present?
+      DB.exec(<<~SQL)
+      CREATE INDEX CONCURRENTLY idx_alert_topics
+      ON topics (id)
+      WHERE deleted_at IS NULL
+      AND NOT closed
+      AND category_id IN (#{category_ids.join(",")})
+      SQL
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/model/topic_spec.rb
+++ b/spec/model/topic_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Topic do
+  fab!(:topic) { Fabricate(:topic) }
+  fab!(:category) { topic.category }
+  fab!(:closed_topic) { Fabricate(:topic, category: category, closed: true) }
+
+  fab!(:plugin_store_row) do
+    PluginStore.set(
+      ::DiscoursePrometheusAlertReceiver::PLUGIN_NAME,
+      'sometoken',
+      { category_id: category.id }
+    )
+  end
+
+  fab!(:firing_alert) do
+    AlertReceiverAlert.create!(
+      topic: topic,
+      status: 'firing',
+      identifier: 'someidentifier',
+      starts_at: Time.zone.now,
+      external_url: "someurl"
+    )
+  end
+
+  fab!(:closed_alert) do
+    AlertReceiverAlert.create!(
+      topic: closed_topic,
+      status: 'resolved',
+      identifier: 'someidentifier',
+      starts_at: Time.zone.now,
+      external_url: "someurl"
+    )
+  end
+
+  describe '.open_alerts' do
+    it 'should return the right count' do
+      expect(Topic.open_alerts).to contain_exactly(firing_alert.topic)
+    end
+  end
+
+  describe '.firing_alerts' do
+    it 'should return the right topics' do
+      expect(Topic.firing_alerts).to contain_exactly(firing_alert.topic)
+    end
+  end
+end


### PR DESCRIPTION
Instead of scanning all the opened topics like the previous query did,
we only scan for topics inside the configured alert categories. A
partial index is also used here so that we don't have to index other
topics unnecessarily.

On one of our own internal instance, this reduces the time spent on this
query from ~20ms to ~4ms.
