### PR TITLE
FIX: Switch alerts category ids cache to distributed cache.

### DIFF
--- a/spec/serializers/site_serializer_spec.rb
+++ b/spec/serializers/site_serializer_spec.rb
@@ -9,11 +9,21 @@ RSpec.describe SiteSerializer do
       SiteSerializer.new(site, root: false, scope: guardian).as_json
     end
 
+    fab!(:category) { Fabricate(:category) }
+
+    fab!(:plugin_store_row) do
+      PluginStore.set(
+        ::DiscoursePrometheusAlertReceiver::PLUGIN_NAME,
+        'sometoken',
+        { category_id: category.id }
+      )
+    end
+
     before do
-      topic1 = Fabricate(:post).topic
-      topic2 = Fabricate(:post).topic
-      topic3 = Fabricate(:post).topic
-      topic4 = Fabricate(:post).topic
+      topic1 = Fabricate(:post, topic: Fabricate(:topic, category: category)).topic
+      topic2 = Fabricate(:post, topic: Fabricate(:topic, category: category)).topic
+      topic3 = Fabricate(:post, topic: Fabricate(:topic, category: category)).topic
+      topic4 = Fabricate(:post, topic: Fabricate(:topic, category: category)).topic
       topic4.trash!
 
       {


### PR DESCRIPTION
A per process cache does not really work well when ActiveRecord
callbacks are only executed on a single process.

Follow-up to ce5e52ba317381fa516da1a08ea095940224457c