### PR TITLE
FIX: get first item from `stream` array to find first post's Id.

### DIFF
--- a/assets/javascripts/discourse/initializers/initialize-discourse-prometheus-alert-receiver.js.es6
+++ b/assets/javascripts/discourse/initializers/initialize-discourse-prometheus-alert-receiver.js.es6
@@ -34,13 +34,13 @@ export default {
         _alertDataChanged() {
           if (this.model && this.model.alert_data && this.model.postStream) {
             this.appEvents.trigger("post-stream:refresh", {
-              id: this.model.postStream.firstPostId,
+              id: this.model.postStream.stream[0],
             });
           }
         },
 
         _quoteAlert(text) {
-          this.quoteState.selected(this.model.postStream.firstPostId, text, {});
+          this.quoteState.selected(this.model.postStream.stream[0], text, {});
           this.send("selectText");
         },
 


### PR DESCRIPTION
Since we removed the property `firstPostId` from the `postStream` model in https://github.com/discourse/discourse/commit/fb5a062b1fbb4fe4fbfe9538115d0f617b604c87, we're now using a different method to find first post's id.