### PR TITLE
FIX: `topic_map` should always be present

### DIFF
--- a/app/controllers/discourse_prometheus_alert_receiver/receiver_controller.rb
+++ b/app/controllers/discourse_prometheus_alert_receiver/receiver_controller.rb
@@ -25,7 +25,8 @@ module DiscoursePrometheusAlertReceiver
       receiver_data = {
         category_id: category.id,
         created_at: Time.zone.now,
-        created_by: current_user.id
+        created_by: current_user.id,
+        topic_map: {}
       }
 
       if params["assignee_group_id"]
@@ -33,7 +34,6 @@ module DiscoursePrometheusAlertReceiver
         raise Discourse::InvalidParameters unless group
 
         receiver_data[:assignee_group_id] = group.id
-        receiver_data[:topic_map] = {}
       end
 
       token = SecureRandom.hex(32)

--- a/spec/integration/discourse_prometheus_alert_receiver/receiver_controller_spec.rb
+++ b/spec/integration/discourse_prometheus_alert_receiver/receiver_controller_spec.rb
@@ -69,7 +69,8 @@ RSpec.describe DiscoursePrometheusAlertReceiver::ReceiverController do
           expect(receiver.value).to eq({
             category_id: category.id,
             created_at: Time.zone.now,
-            created_by: admin.id
+            created_by: admin.id,
+            topic_map: {}
           }.to_json)
         end
       end


### PR DESCRIPTION
The `ProcessAlert` job expects the receiver to always have a topic_map, regardless of whether or not an assignee_group was included when the receiver was initially created.