### PR TITLE
Remove 'priority' system

### DIFF
--- a/app/jobs/concerns/alert_post_mixin.rb
+++ b/app/jobs/concerns/alert_post_mixin.rb
@@ -4,8 +4,6 @@ module AlertPostMixin
   extend ActiveSupport::Concern
 
   FIRING_TAG = "firing".freeze
-  HIGH_PRIORITY_TAG = "priority-high".freeze
-  NEXT_BUSINESS_DAY_SLA = "nbd".freeze
 
   MAX_BUMP_RATE = 5.minutes
 

--- a/app/jobs/regular/process_alert.rb
+++ b/app/jobs/regular/process_alert.rb
@@ -64,13 +64,8 @@ module Jobs
         "#{params["groupLabels"].to_hash.map { |k, v| "#{k}: #{v}" }.join(", ")}"
     end
 
-    def high_priority?(params)
-      params["commonLabels"]["response_sla"] != NEXT_BUSINESS_DAY_SLA
-    end
-
     def tags_from_params(params)
       tags = []
-      tags << HIGH_PRIORITY_TAG if high_priority?(params)
       tags += Array(params["commonLabels"]['datacenter'])
       tags += Array(params["commonAnnotations"]['topic_tags']&.split(','))
       tags

--- a/spec/integration/discourse_prometheus_alert_receiver/receiver_controller_spec.rb
+++ b/spec/integration/discourse_prometheus_alert_receiver/receiver_controller_spec.rb
@@ -479,8 +479,7 @@ RSpec.describe DiscoursePrometheusAlertReceiver::ReceiverController do
 
           expect(topic.tags.pluck(:name)).to contain_exactly(
             datacenter,
-            AlertPostMixin::FIRING_TAG,
-            AlertPostMixin::HIGH_PRIORITY_TAG
+            AlertPostMixin::FIRING_TAG
           )
 
           expect(topic.title).to eq(
@@ -532,8 +531,7 @@ RSpec.describe DiscoursePrometheusAlertReceiver::ReceiverController do
 
           expect(topic.tags.pluck(:name)).to contain_exactly(
             datacenter,
-            AlertPostMixin::FIRING_TAG,
-            AlertPostMixin::HIGH_PRIORITY_TAG
+            AlertPostMixin::FIRING_TAG
           )
         end
       end
@@ -692,7 +690,6 @@ RSpec.describe DiscoursePrometheusAlertReceiver::ReceiverController do
           expect(topic.tags.pluck(:name)).to contain_exactly(
             datacenter,
             AlertPostMixin::FIRING_TAG,
-            AlertPostMixin::HIGH_PRIORITY_TAG
           )
 
           expect(topic.alert_receiver_alerts.pluck(:identifier, :status)).to contain_exactly(
@@ -774,7 +771,6 @@ RSpec.describe DiscoursePrometheusAlertReceiver::ReceiverController do
               datacenter,
               datacenter2,
               AlertPostMixin::FIRING_TAG,
-              AlertPostMixin::HIGH_PRIORITY_TAG
             )
 
             expect(topic.alert_receiver_alerts.pluck(:identifier, :datacenter, :external_url, :status)).to contain_exactly(
@@ -896,7 +892,6 @@ RSpec.describe DiscoursePrometheusAlertReceiver::ReceiverController do
           expect(keyed_topic.tags.pluck(:name)).to contain_exactly(
             datacenter,
             AlertPostMixin::FIRING_TAG,
-            AlertPostMixin::HIGH_PRIORITY_TAG
           )
 
           expect(receiver["topic_map"][alert_name]).to eq(keyed_topic.id)
@@ -958,7 +953,7 @@ RSpec.describe DiscoursePrometheusAlertReceiver::ReceiverController do
             )
 
             expect(topic.tags.pluck(:name)).to contain_exactly(
-              datacenter, AlertPostMixin::HIGH_PRIORITY_TAG
+              datacenter
             )
 
             alert = topic.alert_receiver_alerts.first


### PR DESCRIPTION
If needed, this functionality can be replicated using the more generic `discourse_tags` labels