### PR TITLE
PERF: Improve performance of counting open alert topics.

### DIFF
--- a/app/jobs/concerns/alert_post_mixin.rb
+++ b/app/jobs/concerns/alert_post_mixin.rb
@@ -127,7 +127,7 @@ module AlertPostMixin
   def publish_alert_counts
     MessageBus.publish("/alert-receiver",
       firing_alerts_count: Topic.firing_alerts.count,
-      open_alerts_count: Topic.open_alerts.count
+      open_alerts_count: Topic.open_alerts_count
     )
   end
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -92,9 +92,9 @@ after_initialize do
       .pluck("value::json->'category_id'")
   end
 
-  add_class_method(:topic, :open_alerts) do
-    joins(:alert_receiver_alerts)
-      .where("not topics.closed AND topics.category_id IN (?)", alerts_category_ids_cache)
+  add_class_method(:topic, :open_alerts_count) do
+    ids = Topic.where(closed: false, category_id: alerts_category_ids_cache).pluck(:id)
+    AlertReceiverAlert.select(:topic_id).where(topic_id: ids).distinct.count
   end
 
   add_class_method(:topic, :firing_alerts) do |category_ids = []|
@@ -118,7 +118,7 @@ after_initialize do
   end
 
   add_to_serializer(:site, :open_alerts_count) do
-    Topic.open_alerts.count
+    Topic.open_alerts_count
   end
 
   add_to_serializer(:site, :include_open_alerts_count?) do

--- a/spec/model/topic_spec.rb
+++ b/spec/model/topic_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 describe Topic do
   fab!(:topic) { Fabricate(:topic) }
+  fab!(:topic_2) { Fabricate(:topic) }
   fab!(:category) { topic.category }
   fab!(:closed_topic) { Fabricate(:topic, category: category, closed: true) }
 
@@ -25,6 +26,26 @@ describe Topic do
     )
   end
 
+  fab!(:silenced_alert) do
+    AlertReceiverAlert.create!(
+      topic: topic,
+      status: 'silenced',
+      identifier: 'someidentifier2',
+      starts_at: Time.zone.now,
+      external_url: "someurl"
+    )
+  end
+
+  fab!(:suppresed_alert) do
+    AlertReceiverAlert.create!(
+      topic: topic_2,
+      status: 'suppressed',
+      identifier: 'someidentifier2',
+      starts_at: Time.zone.now,
+      external_url: "someurl"
+    )
+  end
+
   fab!(:closed_alert) do
     AlertReceiverAlert.create!(
       topic: closed_topic,
@@ -35,9 +56,9 @@ describe Topic do
     )
   end
 
-  describe '.open_alerts' do
-    it 'should return the right count' do
-      expect(Topic.open_alerts).to contain_exactly(firing_alert.topic)
+  describe '.open_alerts_count' do
+    it 'should return the distinct count of open topics containing alerts' do
+      expect(Topic.open_alerts_count).to eq(2)
     end
   end
 


### PR DESCRIPTION
In production, we are running the following query:

`SELECT COUNT(*) FROM topics INNER JOIN alert_receiver_alerts arr ON arr.topic_id = topics.id WHERE deleted_at IS NULL AND NOT topics.closed AND topics.category_id IN (1);`

When we run `EXPLAIN ANALYZE`, the above query results uses a merge join
which joins the topics table against the entire `alert_receiver_alerts` table.
As the `alert_receiver_alerts` table grows, this query becomes more
inefficient.

Instead, this commit uses two queries. One to fetch the
open topic ids from the alert category and another query to check if
those topic ids contain alerts. Both query is highly optimized with
indexes.

On our production instance with about 120K alerts, this reduces the query time to count open
alert topics from ~20ms to about ~2ms.

Also this commit fixes a bug where the previous open alerts count did
not account for multiple alerts in a given topic leading to an inflated
count in certain cases.