### PR TITLE
FIX: Prevent time tip pop-up from being hidden

### DIFF
--- a/assets/stylesheets/topic-post.scss
+++ b/assets/stylesheets/topic-post.scss
@@ -53,10 +53,6 @@
     }
   }
 
-  .alert-table-wrapper {
-    overflow-x: auto;
-  }
-
   .alert-receiver-table {
     width: 100%;
     border: 1px solid var(--primary-low);


### PR DESCRIPTION
### Before
<img width="218" alt="image" src="https://user-images.githubusercontent.com/30537603/172728790-dc850562-0ffa-4420-a61d-f50de5597067.png">


### After
<img width="252" alt="image" src="https://user-images.githubusercontent.com/30537603/172728755-b258c571-ddb0-48ca-aceb-69fe05c78fbf.png">
