### PR TITLE
FIX: Drop index concurrently so that it doesn't lock up the table

### DIFF
--- a/app/jobs/regular/create_alert_topics_index.rb
+++ b/app/jobs/regular/create_alert_topics_index.rb
@@ -6,7 +6,7 @@ module Jobs
 
     def execute(_)
       DB.exec(<<~SQL)
-      DROP INDEX IF EXISTS #{ALERT_TOPICS_INDEX_NAME};
+      DROP INDEX #{Rails.env.test? ? '' : 'CONCURRENTLY'} IF EXISTS #{ALERT_TOPICS_INDEX_NAME};
       SQL
 
       if (category_ids = Topic.alerts_category_ids).present?


### PR DESCRIPTION
Error in production which we saw:

```
Message (4 copies reported)
Job exception: ERROR:  canceling statement due to lock timeout

Backtrace
rack-mini-profiler-3.0.0/lib/patches/db/pg.rb:110:in `exec'
rack-mini-profiler-3.0.0/lib/patches/db/pg.rb:110:in `async_exec'
(eval):29:in `async_exec'
mini_sql-1.4.0/lib/mini_sql/postgres/connection.rb:209:in `run'
mini_sql-1.4.0/lib/mini_sql/active_record_postgres/connection.rb:38:in `block in run'
mini_sql-1.4.0/lib/mini_sql/active_record_postgres/connection.rb:34:in `block in with_lock'
activesupport-7.0.3.1/lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `handle_interrupt'
activesupport-7.0.3.1/lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `block in synchronize'
activesupport-7.0.3.1/lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `handle_interrupt'
activesupport-7.0.3.1/lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `synchronize'
mini_sql-1.4.0/lib/mini_sql/active_record_postgres/connection.rb:34:in `with_lock'
mini_sql-1.4.0/lib/mini_sql/active_record_postgres/connection.rb:38:in `run'
mini_sql-1.4.0/lib/mini_sql/postgres/connection.rb:181:in `exec'
/var/www/discourse/plugins/discourse-prometheus-alert-receiver/app/jobs/regular/create_alert_topics_index.rb:13:in `execute'
/var/www/discourse/app/jobs/base.rb:237:in `block (2 levels) in perform'
```