### PR TITLE
UX: Improve behaviour on small-width screens

### DIFF
--- a/assets/javascripts/discourse/components/alert-receiver/date-range.hbs
+++ b/assets/javascripts/discourse/components/alert-receiver/date-range.hbs
@@ -5,8 +5,7 @@
   />
 
   {{#if @endsAt}}
-    -
-    <AlertReceiver::Timestamp
+    -&nbsp;<AlertReceiver::Timestamp
       @date={{this.parsedEnd.date}}
       @time={{this.parsedEnd.time}}
       @hideDate={{this.hideEndDate}}

--- a/assets/javascripts/discourse/components/alert-receiver/timestamp.hbs
+++ b/assets/javascripts/discourse/components/alert-receiver/timestamp.hbs
@@ -1,10 +1,8 @@
-<span class="alert-receiver-date">
-  <span
-    class="discourse-local-date"
-    data-format={{if @hideDate "HH:mm" "YYYY-MM-DD HH:mm"}}
-    data-date={{@date}}
-    data-time={{@time}}
-    data-timezone="UTC"
-    {{did-insert this.applyLocalDates}}
-  >{{@date}}T{{@time}}</span>
-</span>
+<span
+  class="alert-receiver-date discourse-local-date"
+  data-format={{if @hideDate "HH:mm" "YYYY-MM-DD HH:mm"}}
+  data-date={{@date}}
+  data-time={{@time}}
+  data-timezone="UTC"
+  {{did-insert this.applyLocalDates}}
+>{{@date}}T{{@time}}</span>

--- a/assets/stylesheets/topic-post.scss
+++ b/assets/stylesheets/topic-post.scss
@@ -61,6 +61,10 @@
     margin: 1em 0;
   }
 
+  .alert-table-wrapper {
+    overflow-x: scroll;
+  }
+
   tbody {
     border: none;
   }


### PR DESCRIPTION
- Scroll table horizontally instead of overflowing
- Make timestamp ranges wrap to two lines instead of three

Before:
<img width="200" alt="Screenshot 2023-02-06 at 17 45 25" src="https://user-images.githubusercontent.com/6270921/217046239-4306662c-f286-4b42-8d3a-95e98fd52f16.png">

After:
<img width="200" alt="Screenshot 2023-02-06 at 17 45 47" src="https://user-images.githubusercontent.com/6270921/217046290-f7303300-4868-4f25-a5c5-9fc8460b4d66.png"><img width="200" alt="Screenshot 2023-02-06 at 17 45 52" src="https://user-images.githubusercontent.com/6270921/217046315-cecff994-26bc-4a8f-91a0-466ac5451c2a.png">
