### PR TITLE
FIX: Display timestamps as UTC

### DIFF
--- a/assets/javascripts/discourse/components/alert-receiver/timestamp.hbs
+++ b/assets/javascripts/discourse/components/alert-receiver/timestamp.hbs
@@ -4,5 +4,6 @@
   data-date={{@date}}
   data-time={{@time}}
   data-timezone="UTC"
+  data-displayed-timezone="UTC"
   {{did-insert this.applyLocalDates}}
 >{{@date}}T{{@time}}</span>


### PR DESCRIPTION
This regressed in the widget -> glimmer conversion in 5d27f4d26e35e09ba5e58288b61b4ae54797b652