### PR TITLE
UX: Ensure local-dates popover is not clipped

### DIFF
--- a/assets/stylesheets/topic-post.scss
+++ b/assets/stylesheets/topic-post.scss
@@ -70,7 +70,6 @@
   }
 
   table {
-    position: relative;
     width: 100%;
   }
 


### PR DESCRIPTION
978e802ecb83c8397c3e0ae0d2c30173fefee381 introduced `overflow: hidden` on `.alert-table-wrapper`. That caused the local-dates popover to be clipped when it escaped the wrapper.

`position: fixed` elements like the local-dates popover are positioned based on their closest `position: relative` element. Previously, it was the `<table>` itself, which is inside the `overflow: hidden` wrapper. This commit removes that, so that the nearest `position: relative` parent is **outside** the `overflow: hidden` element, thereby avoiding the clipping.

Before:
<img width="442" alt="Screenshot 2023-02-09 at 10 26 46" src="https://user-images.githubusercontent.com/6270921/217786760-1ae4bc7e-af4a-45a8-957d-851cafae6c30.png">

After:

<img width="419" alt="Screenshot 2023-02-09 at 10 26 59" src="https://user-images.githubusercontent.com/6270921/217786802-a4776b23-7309-4e32-9717-37f0a333adc9.png">
