### PR TITLE
DEV: Replace #pluck_first monkey patch with native #pick

### DIFF
--- a/app/jobs/concerns/alert_post_mixin.rb
+++ b/app/jobs/concerns/alert_post_mixin.rb
@@ -51,7 +51,7 @@ module AlertPostMixin
 
   def prev_topic_link(topic_id)
     return "" if topic_id.nil?
-    return "" unless created_at = Topic.where(id: topic_id).pluck_first(:created_at)
+    return "" unless created_at = Topic.where(id: topic_id).pick(:created_at)
     "[Previous alert](#{Discourse.base_url}/t/#{topic_id}) #{local_date(created_at.to_s)}\n\n"
   end
 


### PR DESCRIPTION
### What is this change?

We have replaced the `#pluck_first` freedom patch with the native `#pick` in core [here](https://github.com/discourse/discourse/pull/19893).

This change is updates this plugin in the same fashion.