### PR TITLE
DEV: Update tests to work with new group access

### DIFF
--- a/spec/integration/discourse_prometheus_alert_receiver/notification_overrides_spec.rb
+++ b/spec/integration/discourse_prometheus_alert_receiver/notification_overrides_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe DiscoursePrometheusAlertReceiver::ReceiverController do
   end
 
   it "doesn't break non-system posts" do
-    create_topic(user: Fabricate(:user), category: alert_category)
+    create_topic(user: Fabricate(:user, refresh_auto_groups: true), category: alert_category)
     expect(Notification.count).to eq(1)
   end
 


### PR DESCRIPTION
### What is this change?

We're updating a bunch of site settings that restrict access to use groups instead of TL. This requires certain specs to ensure that auto-groups are fabricated in order to work.