### PR TITLE
FEATURE: Update `topic_assignee` and `topic_group_assignee` annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,17 +55,15 @@ randomly-selected member of a specified group.
   to give a brief description of the problem, and potentially links to a
   runbook or other useful information.
 
-- **`topic_assignee`**: This overrides the random group member selection,
-  and allows you to "force-assign" alerts to one person. The intended
-  use-case for this is during the development phase of a new alert, to
-  prevent spurious false-positives from annoying everyone. The forced
-  assignee does not need to be a member of the group that assignees are
-  normally chosen from.
+- **`topic_assignee`**: Accepts `User#username`. Automatically
+  assigns the created topic to the specified user. Note that the specified user
+  has to be an admin or is a member of an assignable group given by the
+  `assign_allowed_on_groups` site setting.
 
-- **`group_topic_assignee`**: Given the `Group#id` or `Group#name` for a group,
-  this overrides the `assignee_group_id` that was created with the receiver
-  token. A person in the group will be randomly selected for assignment to the
-  alert.
+- **`topic_group_assignee`**: Accepts `Group#name`. Automatically
+  assigns the created topic to the specified group. Note that the specified
+  group has to at least be assignable by an admin. The assignability of a group
+  can be configured at the `/g/admins/manage/interaction` path.
 
 - **`description`** -- the description will be displayed under each alert.
 

--- a/app/jobs/regular/process_alert.rb
+++ b/app/jobs/regular/process_alert.rb
@@ -98,25 +98,14 @@ module Jobs
           PluginStore.set(::DiscoursePrometheusAlertReceiver::PLUGIN_NAME, @token, receiver)
 
           assignee =
-            if params["commonAnnotations"]["topic_assignee"]
-              User.find_by(username: params["commonAnnotations"]["topic_assignee"])
-            elsif params["commonAnnotations"]["group_topic_assignee"]
-              random_group_member(params["commonAnnotations"]["group_topic_assignee"])
+            if username = params["commonAnnotations"]["topic_assignee"]
+              User.where("username_lower = ?", username.downcase).first
+            elsif group_name = params["commonAnnotations"]["topic_group_assignee"]
+              Group.where("LOWER(name) = ?", group_name.downcase).first
             end
 
           assign_alert(t, receiver, assignee: assignee)
         end
-    end
-
-    def random_group_member(id_or_name)
-      attributes =
-        if id_or_name.to_i != 0
-          { id: id_or_name.to_i }
-        else
-          "LOWER(name) LIKE '#{id_or_name}'"
-        end
-
-      Group.find_by(attributes).users.sample
     end
 
     def assign_alert(topic, receiver, assignee: nil)


### PR DESCRIPTION
This commit changes two main things:

1. `topic_assignee` will only accept `User#username` now. Having to
   support both `User#username` and `User#id` complicates the code too
   much.

2. Rename `group_topic_assignee` to `topic_group_assignee` which will
   accept `Group#name`. When the annotation is present, the topic will
   automatically be assigned to the specified group`
