### PR TITLE
FEATURE: Show indicator when re-firing alerts were previously silenced

### DIFF
--- a/app/models/alert_receiver_alert.rb
+++ b/app/models/alert_receiver_alert.rb
@@ -26,7 +26,14 @@ class AlertReceiverAlert < ActiveRecord::Base
 
     query = <<~SQL
       UPDATE alert_receiver_alerts alerts
-      SET status=data.status, ends_at=data.ends_at::timestamp, description=data.description
+      SET
+        status=data.status,
+        ends_at=data.ends_at::timestamp,
+        description=data.description,
+        last_suppressed_at = CASE
+          WHEN data.status = 'suppressed' THEN CURRENT_TIMESTAMP
+          ELSE alerts.last_suppressed_at
+        END
       FROM (values #{values_string})
         AS data(topic_id, external_url, identifier, status, ends_at, description)
       WHERE alerts.topic_id = data.topic_id
@@ -49,7 +56,8 @@ class AlertReceiverAlert < ActiveRecord::Base
     return [] if alerts.blank?
 
     insert_columns = column_names - ["id"]
-    update_columns = insert_columns - %w[topic_id identifier starts_at external_url]
+    update_columns =
+      insert_columns - %w[topic_id identifier starts_at external_url last_suppressed_at]
 
     array_to_insert = alerts.pluck(*insert_columns.map(&:to_sym))
     hash_to_insert = Hash[array_to_insert.each_with_index.map { |v, i| [:"value#{i}", v] }]

--- a/app/serializers/alert_receiver_alert.rb
+++ b/app/serializers/alert_receiver_alert.rb
@@ -10,5 +10,6 @@ class AlertReceiverAlertSerializer < ApplicationSerializer
              :external_url,
              :generator_url,
              :link_url,
-             :link_text
+             :link_text,
+             :last_suppressed_at
 end

--- a/assets/javascripts/discourse/components/alert-receiver/row.gjs
+++ b/assets/javascripts/discourse/components/alert-receiver/row.gjs
@@ -11,6 +11,24 @@ export default class AlertReceiverRow extends Component {
   @service siteSettings;
   @controller("topic") topicController;
 
+  get wasRecentlySuppressed() {
+    if (!this.args.alert.last_suppressed_at) {
+      return false;
+    }
+
+    const suppressedDate = new Date(this.args.alert.last_suppressed_at);
+    const daysSinceSuppressed =
+      (Date.now() - suppressedDate.getTime()) / (1000 * 60 * 60 * 24);
+    return daysSinceSuppressed <= 90;
+  }
+
+  get suppressedDateFormatted() {
+    if (!this.args.alert.last_suppressed_at) {
+      return "";
+    }
+    return new Date(this.args.alert.last_suppressed_at).toLocaleDateString();
+  }
+
   get generatorUrl() {
     const {
       generator_url: url,
@@ -155,7 +173,18 @@ export default class AlertReceiverRow extends Component {
 
   <template>
     <tr>
-      <td><a href={{this.generatorUrl}}>{{@alert.identifier}}</a></td>
+      <td>
+        <a href={{this.generatorUrl}}>{{@alert.identifier}}</a>
+        {{#if this.wasRecentlySuppressed}}
+          <span
+            class="alert-was-suppressed"
+            title="This alert was previously silenced on {{this.suppressedDateFormatted}}"
+          >
+            {{icon "bell-slash"}}
+            <span class="was-suppressed-text">Previously silenced</span>
+          </span>
+        {{/if}}
+      </td>
       <td>
         <DateRange @startsAt={{@alert.starts_at}} @endsAt={{@alert.ends_at}} />
       </td>

--- a/assets/stylesheets/topic-post.scss
+++ b/assets/stylesheets/topic-post.scss
@@ -104,4 +104,32 @@
       display: none;
     }
   }
+
+  .alert-was-suppressed {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25em;
+    margin-left: 0.5em;
+    padding: 0.2em 0.5em;
+    background-color: var(--tertiary-low);
+    border-radius: 3px;
+    font-size: 0.85em;
+    color: var(--tertiary);
+
+    .d-icon {
+      font-size: 0.9em;
+    }
+
+    .was-suppressed-text {
+      font-weight: 500;
+    }
+  }
+
+  @media (width <= 767px) {
+    .alert-was-suppressed {
+      .was-suppressed-text {
+        display: none;
+      }
+    }
+  }
 }

--- a/db/migrate/20260328163424_add_suppression_tracking_to_alert_receiver_alerts.rb
+++ b/db/migrate/20260328163424_add_suppression_tracking_to_alert_receiver_alerts.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSuppressionTrackingToAlertReceiverAlerts < ActiveRecord::Migration[7.1]
+  def change
+    add_column :alert_receiver_alerts, :last_suppressed_at, :datetime
+  end
+end

--- a/spec/model/alert_receiver_alert_spec.rb
+++ b/spec/model/alert_receiver_alert_spec.rb
@@ -172,4 +172,106 @@ RSpec.describe AlertReceiverAlert do
     expect(AlertReceiverAlert.count).to eq(3)
     expect(AlertReceiverAlert.firing.count).to eq(3)
   end
+
+  describe "suppression tracking" do
+    it "sets last_suppressed_at when alert becomes suppressed" do
+      AlertReceiverAlert.update_alerts([alert(identifier: "myid1")])
+
+      alert_record = AlertReceiverAlert.find_by(identifier: "myid1")
+      expect(alert_record.last_suppressed_at).to be_nil
+
+      AlertReceiverAlert.update_alerts([alert(identifier: "myid1", status: "suppressed")])
+
+      alert_record.reload
+      expect(alert_record.last_suppressed_at).to be_present
+    end
+
+    it "preserves last_suppressed_at when alert resolves" do
+      AlertReceiverAlert.update_alerts([alert(identifier: "myid1")])
+      AlertReceiverAlert.update_alerts([alert(identifier: "myid1", status: "suppressed")])
+
+      alert_record = AlertReceiverAlert.find_by(identifier: "myid1")
+      suppressed_at = alert_record.last_suppressed_at
+
+      AlertReceiverAlert.update_alerts([alert(identifier: "myid1", status: "resolved")])
+
+      alert_record.reload
+      expect(alert_record.last_suppressed_at).to eq_time(suppressed_at)
+    end
+
+    it "preserves last_suppressed_at when alert re-fires" do
+      AlertReceiverAlert.update_alerts([alert(identifier: "myid1")])
+      AlertReceiverAlert.update_alerts([alert(identifier: "myid1", status: "suppressed")])
+
+      alert_record = AlertReceiverAlert.find_by(identifier: "myid1")
+      suppressed_at = alert_record.last_suppressed_at
+
+      AlertReceiverAlert.update_alerts([alert(identifier: "myid1", status: "firing")])
+
+      alert_record.reload
+      expect(alert_record.last_suppressed_at).to eq_time(suppressed_at)
+      expect(alert_record.status).to eq("firing")
+    end
+
+    it "updates last_suppressed_at on re-suppression" do
+      AlertReceiverAlert.update_alerts([alert(identifier: "myid1")])
+      AlertReceiverAlert.update_alerts([alert(identifier: "myid1", status: "suppressed")])
+
+      alert_record = AlertReceiverAlert.find_by(identifier: "myid1")
+      expect(alert_record.last_suppressed_at).to be_present
+
+      # Re-fire then suppress again
+      AlertReceiverAlert.update_alerts([alert(identifier: "myid1", status: "firing")])
+      AlertReceiverAlert.update_alerts([alert(identifier: "myid1", status: "suppressed")])
+
+      alert_record.reload
+      expect(alert_record.last_suppressed_at).to be_present
+    end
+
+    it "does not set last_suppressed_at for alerts that only fire" do
+      AlertReceiverAlert.update_alerts([alert(identifier: "myid1", status: "firing")])
+
+      alert_record = AlertReceiverAlert.find_by(identifier: "myid1")
+      expect(alert_record.last_suppressed_at).to be_nil
+    end
+
+    it "handles multiple alerts with different suppression histories" do
+      AlertReceiverAlert.update_alerts(
+        [alert(identifier: "myid1"), alert(identifier: "myid2"), alert(identifier: "myid3")],
+      )
+
+      # Suppress only myid1 and myid2
+      AlertReceiverAlert.update_alerts(
+        [
+          alert(identifier: "myid1", status: "suppressed"),
+          alert(identifier: "myid2", status: "suppressed"),
+        ],
+      )
+
+      alert1 = AlertReceiverAlert.find_by(identifier: "myid1")
+      alert2 = AlertReceiverAlert.find_by(identifier: "myid2")
+      alert3 = AlertReceiverAlert.find_by(identifier: "myid3")
+
+      expect(alert1.last_suppressed_at).to be_present
+      expect(alert2.last_suppressed_at).to be_present
+      expect(alert3.last_suppressed_at).to be_nil
+
+      # All fire again
+      AlertReceiverAlert.update_alerts(
+        [
+          alert(identifier: "myid1", status: "firing"),
+          alert(identifier: "myid2", status: "firing"),
+          alert(identifier: "myid3", status: "firing"),
+        ],
+      )
+
+      alert1.reload
+      alert2.reload
+      alert3.reload
+
+      expect(alert1.last_suppressed_at).to be_present
+      expect(alert2.last_suppressed_at).to be_present
+      expect(alert3.last_suppressed_at).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
Track when alerts are suppressed via `last_suppressed_at` timestamp. When an alert re-fires within 90 days of being silenced, display a bell-slash badge so staff can extend the silence rather than re-investigate from scratch.