### PR TITLE
FIX: Only show "previously silenced" badge on firing alerts

### DIFF
--- a/app/models/alert_receiver_alert.rb
+++ b/app/models/alert_receiver_alert.rb
@@ -32,6 +32,7 @@ class AlertReceiverAlert < ActiveRecord::Base
         description=data.description,
         last_suppressed_at = CASE
           WHEN data.status = 'suppressed' THEN CURRENT_TIMESTAMP
+          WHEN data.status = 'resolved' THEN NULL
           ELSE alerts.last_suppressed_at
         END
       FROM (values #{values_string})
@@ -113,7 +114,7 @@ class AlertReceiverAlert < ActiveRecord::Base
         AND db_alerts.starts_at < :stale_threshold
       )
       UPDATE alert_receiver_alerts alerts
-      SET status='stale'
+      SET status='stale', last_suppressed_at=NULL
       FROM stale_alerts
       WHERE stale_alerts.id = alerts.id
       RETURNING alerts.topic_id

--- a/assets/javascripts/discourse/components/alert-receiver/row.gjs
+++ b/assets/javascripts/discourse/components/alert-receiver/row.gjs
@@ -22,6 +22,13 @@ export default class AlertReceiverRow extends Component {
     return daysSinceSuppressed <= 90;
   }
 
+  // The badge only makes sense on a currently-firing alert. A suppressed
+  // alert is shown under the "Silenced" group and would otherwise carry a
+  // just-stamped last_suppressed_at; resolved/stale alerts are uninteresting.
+  get showsPreviouslySilencedBadge() {
+    return this.args.alert.status === "firing" && this.wasRecentlySuppressed;
+  }
+
   get suppressedDateFormatted() {
     if (!this.args.alert.last_suppressed_at) {
       return "";
@@ -175,7 +182,7 @@ export default class AlertReceiverRow extends Component {
     <tr>
       <td>
         <a href={{this.generatorUrl}}>{{@alert.identifier}}</a>
-        {{#if this.wasRecentlySuppressed}}
+        {{#if this.showsPreviouslySilencedBadge}}
           <span
             class="alert-was-suppressed"
             title="This alert was previously silenced on {{this.suppressedDateFormatted}}"

--- a/spec/model/alert_receiver_alert_spec.rb
+++ b/spec/model/alert_receiver_alert_spec.rb
@@ -186,17 +186,51 @@ RSpec.describe AlertReceiverAlert do
       expect(alert_record.last_suppressed_at).to be_present
     end
 
-    it "preserves last_suppressed_at when alert resolves" do
+    it "clears last_suppressed_at when alert resolves" do
       AlertReceiverAlert.update_alerts([alert(identifier: "myid1")])
       AlertReceiverAlert.update_alerts([alert(identifier: "myid1", status: "suppressed")])
 
       alert_record = AlertReceiverAlert.find_by(identifier: "myid1")
-      suppressed_at = alert_record.last_suppressed_at
+      expect(alert_record.last_suppressed_at).to be_present
 
       AlertReceiverAlert.update_alerts([alert(identifier: "myid1", status: "resolved")])
 
       alert_record.reload
-      expect(alert_record.last_suppressed_at).to eq_time(suppressed_at)
+      expect(alert_record.last_suppressed_at).to be_nil
+    end
+
+    it "clears last_suppressed_at when alert goes stale" do
+      AlertReceiverAlert.update_alerts([alert(identifier: "myid1")])
+      AlertReceiverAlert.update_alerts([alert(identifier: "myid1", status: "suppressed")])
+
+      alert_record = AlertReceiverAlert.find_by(identifier: "myid1")
+      expect(alert_record.last_suppressed_at).to be_present
+
+      AlertReceiverAlert.update_alerts(
+        [alert(identifier: "myid2")],
+        mark_stale_external_url: "alerts.dc.example.com",
+      )
+
+      alert_record.reload
+      expect(alert_record.status).to eq("stale")
+      expect(alert_record.last_suppressed_at).to be_nil
+    end
+
+    it "starts a later firing of the same identity with no suppression marker" do
+      # Episode 1: fires, is silenced, then resolves.
+      AlertReceiverAlert.update_alerts([alert(identifier: "myid1")])
+      AlertReceiverAlert.update_alerts([alert(identifier: "myid1", status: "suppressed")])
+      AlertReceiverAlert.update_alerts([alert(identifier: "myid1", status: "resolved")])
+
+      # Episode 2: a brand-new firing of the same alert identity. The partial
+      # unique index only covers firing/suppressed rows, so the resolved row
+      # remains and a fresh row is inserted for the new episode; the new
+      # row must not inherit any suppression marker.
+      AlertReceiverAlert.update_alerts([alert(identifier: "myid1", status: "firing")])
+
+      new_record = AlertReceiverAlert.firing.find_by(identifier: "myid1")
+      expect(new_record).to be_present
+      expect(new_record.last_suppressed_at).to be_nil
     end
 
     it "preserves last_suppressed_at when alert re-fires" do

--- a/test/javascripts/acceptance/alert-receiver-test.js
+++ b/test/javascripts/acceptance/alert-receiver-test.js
@@ -4,7 +4,7 @@ import { cloneJSON } from "discourse/lib/object";
 import topicFixtures from "discourse/tests/fixtures/topic";
 import { acceptance, query } from "discourse/tests/helpers/qunit-helpers";
 
-function alertData(status, datacenter, id) {
+function alertData(status, datacenter, id, lastSuppressedAt = null) {
   const data = {
     status,
     identifier: id,
@@ -16,6 +16,7 @@ function alertData(status, datacenter, id) {
       "https://metrics.sjc1.discourse.cloud/graph?g0.expr=mymetric&g0.tab=1",
     link_url:
       "https://logs.sjc1.discourse.cloud/app/kibana#/discover?_g=()&_a=(columns:!(),filters:!((query:(match:(moby.name:(query:mycontainer,type:phrase))))))",
+    last_suppressed_at: lastSuppressedAt,
   };
 
   if (status === "resolved") {
@@ -103,5 +104,51 @@ acceptance(`Alert Receiver`, function (needs) {
     );
 
     assert.dom(".discourse-local-date").exists("dates are output");
+  });
+});
+
+acceptance(`Alert Receiver - previously silenced indicator`, function (needs) {
+  needs.user();
+  needs.settings({ discourse_local_dates_enabled: true });
+
+  const recent = new Date().toISOString();
+
+  needs.pretender((server, helper) => {
+    const json = cloneJSON(topicFixtures["/t/280/1.json"]);
+
+    json.alert_data = [
+      // Firing again after a silence lapsed: badge should show.
+      alertData("firing", "sjc1", "refired", recent),
+      // Currently silenced (shown under "Silenced"): badge must NOT show,
+      // even though last_suppressed_at is recent.
+      alertData("suppressed", "sjc1", "stillsilenced", recent),
+      // Firing but never suppressed: no badge.
+      alertData("firing", "sjc1", "neversilenced"),
+    ];
+
+    server.get("/t/281.json", () => {
+      return helper.response(json);
+    });
+  });
+
+  test("shows the badge only on firing alerts that were recently suppressed", async (assert) => {
+    await visit("/t/internationalization-localization/281");
+
+    assert
+      .dom(
+        ".prometheus-alert-receiver [data-alert-status='firing'] .alert-was-suppressed"
+      )
+      .exists(
+        { count: 1 },
+        "the re-fired alert shows the previously-silenced badge"
+      );
+
+    assert
+      .dom(
+        ".prometheus-alert-receiver [data-alert-status='suppressed'] .alert-was-suppressed"
+      )
+      .doesNotExist(
+        "a currently-silenced alert does not show the previously-silenced badge"
+      );
   });
 });


### PR DESCRIPTION
The "previously silenced" indicator was rendering on alerts that were currently silenced (in the "Silenced" group), and stamping the date as today, because the component only checked `last_suppressed_at` and the timestamp was being refreshed on every observation of the current suppression. Gate the badge on `status === "firing"` so it can only appear on alerts that re-fired after a silence lapsed.

Additionally, clear `last_suppressed_at` when an alert resolves or goes stale. Without this, the unique (`topic_id`, `external_url`, `identifier`) upsert reuses the same DB row for a later, unrelated firing of the same alert identity, which would inherit a stale suppression marker and show "previously silenced" with a date from a prior episode.