### PR TITLE
DEV: Replace QuoteState abuse with direct composer.open for quote alert

### DIFF
--- a/assets/javascripts/discourse/components/alert-receiver/row.gjs
+++ b/assets/javascripts/discourse/components/alert-receiver/row.gjs
@@ -4,11 +4,15 @@ import { action } from "@ember/object";
 import { service } from "@ember/service";
 import DButton from "discourse/components/d-button";
 import icon from "discourse/helpers/d-icon";
+import { buildQuote } from "discourse/lib/quote";
+import Composer from "discourse/models/composer";
 import { i18n } from "discourse-i18n";
 import DateRange from "./date-range";
 
 export default class AlertReceiverRow extends Component {
   @service siteSettings;
+  @service composer;
+  @service appEvents;
   @controller("topic") topicController;
 
   get wasRecentlySuppressed() {
@@ -148,7 +152,7 @@ export default class AlertReceiverRow extends Component {
   }
 
   @action
-  quoteAlert() {
+  async quoteAlert() {
     const {
       identifier,
       datacenter,
@@ -163,12 +167,30 @@ export default class AlertReceiverRow extends Component {
       alertString += ` - ${description}`;
     }
 
-    this.topicController.quoteState.selected(
-      this.topicController.model.postStream.stream[0],
-      alertString,
-      {}
-    );
-    this.topicController.send("selectText");
+    const topic = this.topicController.model;
+    const postStream = topic.postStream;
+    const firstPostId = postStream.stream[0];
+    const firstPost =
+      postStream.findLoadedPost(firstPostId) ??
+      (await postStream.loadPost(firstPostId));
+
+    if (!firstPost) {
+      return;
+    }
+
+    const quotedText = buildQuote(firstPost, alertString, {});
+
+    if (this.composer.get("model.viewOpen")) {
+      this.appEvents.trigger("composer:insert-block", quotedText);
+    } else {
+      await this.composer.open({
+        action: Composer.REPLY,
+        draftKey: topic.draft_key,
+        draftSequence: topic.draft_sequence,
+        topic,
+        quote: quotedText,
+      });
+    }
   }
 
   <template>

--- a/test/javascripts/acceptance/alert-receiver-test.js
+++ b/test/javascripts/acceptance/alert-receiver-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { cloneJSON } from "discourse/lib/object";
 import topicFixtures from "discourse/tests/fixtures/topic";
@@ -103,5 +103,31 @@ acceptance(`Alert Receiver`, function (needs) {
     );
 
     assert.dom(".discourse-local-date").exists("dates are output");
+  });
+
+  test("quote alert button opens composer with the alert as a quote of the first post", async (assert) => {
+    await visit("/t/internationalization-localization/281");
+
+    const quoteButton = query(
+      ".prometheus-alert-receiver [data-alert-status='firing'] table tr td:last-child button.btn-icon"
+    );
+    await click(quoteButton);
+
+    assert.dom(".d-editor-input").exists("composer is opened");
+
+    const reply = query(".d-editor-input").value;
+
+    assert.true(
+      reply.includes("[quote=") && reply.includes("post:1"),
+      `composer is pre-filled with a quote of the first post (got: ${reply})`
+    );
+    assert.true(
+      reply.includes("**myalert5**"),
+      "the alert identifier is rendered in bold markdown"
+    );
+    assert.true(
+      reply.includes("[date=2020-07-27 time=17:26:49"),
+      "the alert timestamp uses the local-date bbcode"
+    );
   });
 });


### PR DESCRIPTION
The quote-alert action was using topicController.quoteState.selected() as a transport to inject a pre-built alert string into the composer.

Discourse core is moving QuoteState toward a stricter "DOM selection only" contract (with a deprecation warning for the 3-arg form), so this migrates the plugin to build the quote with `buildQuote(post, markdown, opts)` and open the composer directly.

Also adds an acceptance test that clicks the quote button and asserts the composer is pre-filled with the expected quote markdown.